### PR TITLE
Query Firestore using CLI - demo only

### DIFF
--- a/scripts/scratch_query/firestore_query.py
+++ b/scripts/scratch_query/firestore_query.py
@@ -10,46 +10,64 @@ all collections.
 
 EXAMPLES
 # Query Firestore with fixed queries
-python firestore_query.py
+python firestore_query.py is_living array_contains yes
 """
-
+import argparse
 from google.cloud import firestore
+import warnings
 
-matching_studies = set()
-db = firestore.Client()
-cm = db.collection(u'cell_metadata')
-living_query = cm.where(u'name', u'==', u'is_living').stream()
-for doc in living_query:
-    query_path = 'cell_metadata/' + doc.id + '/data'
-    # foo = "cell_metadata/jkIaZbCKXdyEeZOhSDGS/data"
-    # subdocs = db.collection(query_path).stream()  # all subdocs
-    subdocs = (
-        db.collection(query_path).where(u'values', u'array_contains', u'yes').stream()
+warnings.filterwarnings(
+    "ignore", "Your application has authenticated using end user credentials"
+)
+
+
+def create_parser():
+    """Parse command line values for firestore_query
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    # print(u'{} => {}'.format(doc.study_accession))
-    # results = subdocs.stream()
-    for subdoc in subdocs:
-        # print(u'{} => {}'.format(subdoc.id, subdoc.to_dict()))
-        test = doc.to_dict()
-        matching_studies.add(test['study_accession'])
-        # for key, value in doc.to_dict().items():
-        #     print(key, value)
+    # parser.add_argument(
+    #     '--output',
+    #     '-o',
+    #     type=str,
+    #     help='Output file name [optional]',
+    #     default=None
+    # )
+    parser.add_argument('metadata', help='study metadata being queried')
+    parser.add_argument('comparison_operation', help='comparison operation for query')
+    parser.add_argument('value', help='value for comparison')
+    return parser
+
+
+def match_query(query_params):
+    metadata, operator, value = query_params
+    matching_studies = set()
+    db = firestore.Client()
+    cm = db.collection(u'cell_metadata')
+    living_query = cm.where(u'name', u'==', metadata).stream()
+    for doc in living_query:
+        query_path = 'cell_metadata/' + doc.id + '/data'
+        # foo = "cell_metadata/jkIaZbCKXdyEeZOhSDGS/data"
+        # subdocs = db.collection(query_path).stream()  # all subdocs
+        subdocs = db.collection(query_path).where(u'values', operator, value).stream()
         # print(u'{} => {}'.format(doc.study_accession))
-print('Studies matching query:', matching_studies)
+        # results = subdocs.stream()
+        for subdoc in subdocs:
+            # print(u'{} => {}'.format(subdoc.id, subdoc.to_dict()))
+            test = doc.to_dict()
+            matching_studies.add(test['study_accession'])
+            # for key, value in doc.to_dict().items():
+            #     print(key, value)
+            # print(u'{} => {}'.format(doc.study_accession))
+    if matching_studies:
+        return matching_studies
+    else:
+        return None
 
-# yes_living_query = (
-#     db.collection(u'cell_metadata/jkIaZbCKXdyEeZOhSDGS/data').where(u'values', u'==', u'yes').stream()
-# )
-# for doc in yes_living_query:
-#     print(u'{} => {}'.format(doc.id, doc.to_dict()))
 
-
-# cm = db.collection(u'cell_metadata')
-# all_docs = cm.stream()
-# for doc in all_docs:
-#     print(u'{} => {}'.format(doc.id, doc.to_dict()))
-
-# living_query = cm.where(u'name', u'==', u'is_living')
-
-# for doc in living_query:
-#     print(u'{} => {}'.format(doc.id, doc.to_dict()))
+if __name__ == '__main__':
+    args = create_parser().parse_args()
+    query_params = (args.metadata, args.comparison_operation, args.value)
+    matches = match_query(query_params)
+    print('Studies matching query:', matches)

--- a/scripts/scratch_query/firestore_query.py
+++ b/scripts/scratch_query/firestore_query.py
@@ -1,0 +1,55 @@
+"""Firestore query examples using python client.
+
+DESCRIPTION
+This cli runs a fixed set of queries against the Firestore cell_metadata collection.
+
+PREREQUISITES
+You must have Google Cloud Firestore installed, authenticated, and
+configured. Must have Python 3.6 or higher. Indexing must be turned off for
+all collections.
+
+EXAMPLES
+# Query Firestore with fixed queries
+python firestore_query.py
+"""
+
+from google.cloud import firestore
+
+matching_studies = set()
+db = firestore.Client()
+cm = db.collection(u'cell_metadata')
+living_query = cm.where(u'name', u'==', u'is_living').stream()
+for doc in living_query:
+    query_path = 'cell_metadata/' + doc.id + '/data'
+    # foo = "cell_metadata/jkIaZbCKXdyEeZOhSDGS/data"
+    # subdocs = db.collection(query_path).stream()  # all subdocs
+    subdocs = (
+        db.collection(query_path).where(u'values', u'array_contains', u'yes').stream()
+    )
+    # print(u'{} => {}'.format(doc.study_accession))
+    # results = subdocs.stream()
+    for subdoc in subdocs:
+        # print(u'{} => {}'.format(subdoc.id, subdoc.to_dict()))
+        test = doc.to_dict()
+        matching_studies.add(test['study_accession'])
+        # for key, value in doc.to_dict().items():
+        #     print(key, value)
+        # print(u'{} => {}'.format(doc.study_accession))
+print('Studies matching query:', matching_studies)
+
+# yes_living_query = (
+#     db.collection(u'cell_metadata/jkIaZbCKXdyEeZOhSDGS/data').where(u'values', u'==', u'yes').stream()
+# )
+# for doc in yes_living_query:
+#     print(u'{} => {}'.format(doc.id, doc.to_dict()))
+
+
+# cm = db.collection(u'cell_metadata')
+# all_docs = cm.stream()
+# for doc in all_docs:
+#     print(u'{} => {}'.format(doc.id, doc.to_dict()))
+
+# living_query = cm.where(u'name', u'==', u'is_living')
+
+# for doc in living_query:
+#     print(u'{} => {}'.format(doc.id, doc.to_dict()))

--- a/scripts/scratch_query/firestore_query.py
+++ b/scripts/scratch_query/firestore_query.py
@@ -9,8 +9,12 @@ configured. Must have Python 3.6 or higher. Indexing must be turned off for
 all collections.
 
 EXAMPLES
-# Query Firestore with fixed queries
-python firestore_query.py is_living array_contains yes
+# Query Firestore cell_metadata, supplying known good metadata names and values queries
+python firestore_query.py is_living yes
+python firestore_query.py species__ontology_label "Homo sapiens"
+python firestore_query.py sex male
+python firestore_query.py sex female
+python firestore_query.py sex unknown
 """
 import argparse
 from google.cloud import firestore
@@ -27,39 +31,28 @@ def create_parser():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    # parser.add_argument(
-    #     '--output',
-    #     '-o',
-    #     type=str,
-    #     help='Output file name [optional]',
-    #     default=None
-    # )
     parser.add_argument('metadata', help='study metadata being queried')
-    parser.add_argument('comparison_operation', help='comparison operation for query')
     parser.add_argument('value', help='value for comparison')
     return parser
 
 
 def match_query(query_params):
-    metadata, operator, value = query_params
+    metadata, value = query_params
     matching_studies = set()
     db = firestore.Client()
     cm = db.collection(u'cell_metadata')
     living_query = cm.where(u'name', u'==', metadata).stream()
     for doc in living_query:
         query_path = 'cell_metadata/' + doc.id + '/data'
-        # foo = "cell_metadata/jkIaZbCKXdyEeZOhSDGS/data"
-        # subdocs = db.collection(query_path).stream()  # all subdocs
-        subdocs = db.collection(query_path).where(u'values', operator, value).stream()
-        # print(u'{} => {}'.format(doc.study_accession))
-        # results = subdocs.stream()
+        subdocs = (
+            db.collection(query_path)
+            .where(u'values', u'array_contains', value)
+            .stream()
+        )
         for subdoc in subdocs:
             # print(u'{} => {}'.format(subdoc.id, subdoc.to_dict()))
             test = doc.to_dict()
             matching_studies.add(test['study_accession'])
-            # for key, value in doc.to_dict().items():
-            #     print(key, value)
-            # print(u'{} => {}'.format(doc.study_accession))
     if matching_studies:
         return matching_studies
     else:
@@ -68,6 +61,6 @@ def match_query(query_params):
 
 if __name__ == '__main__':
     args = create_parser().parse_args()
-    query_params = (args.metadata, args.comparison_operation, args.value)
+    query_params = (args.metadata, args.value)
     matches = match_query(query_params)
     print('Studies matching query:', matches)


### PR DESCRIPTION
This CLI queries the Firestore cell_metadata collection to show successful ingest of Alexandria metadata. Provided pairs of known-good sets of metadata,value information, this CLI will determine the set of studies that match all provided criteria.

```
python firestore_query.py --query species__ontology_label,"Homo sapiens" --query is_living,yes --query sex,female

Studies with cells where species__ontology_label is Homo sapiens : {'SCP666', 'SCP777', 'SCP888'}
Studies with cells where is_living is yes : {'SCP777', 'SCP888'}
Studies with cells where sex is female : {'SCP666', 'SCP777'}
++++++++++++++++++++
Studies with cells matching all criteria: {'SCP777'}
```

Caveats:
• using cell_metadata collection requires OR logic which is implemented in Python and not via Firestore query
• cells collection is the intended collection for this type of query in production
• "unique_values" would ideally be leveraged if querying cell_metadata but only populated by work from SCP-1833 which will integrated in time for the demo (would eliminate querying of subdocs)
• script uses end user credentials - warnings intentionally suppressed for demo

This fulfills [SCP-1837](https://broadworkbench.atlassian.net/browse/SCP-1837).