### PR TITLE
Bug fixes for Cluster data model

### DIFF
--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -16,8 +16,8 @@ DOCUMENT_LIMIT_BYTES = 1_048_576
 
 class CellMetadata(IngestFiles):
     ALLOWED_FILE_TYPES = ["text/csv", "text/plain", "text/tab-separated-values"]
-    SUBCOLLECTION_NAME = "cell_metadata"
-    COLLECTION_NAME = "data"
+    COLLECTION_NAME = "cell_metadata"
+    SUBCOLLECTION_NAME = "data"
 
     def __init__(self, file_path, file_id: str, study_accession: str, *args, **kwargs):
 
@@ -160,14 +160,6 @@ class CellMetadata(IngestFiles):
                 # Reset sum and add storage size at current index
                 sum = starting_sum + cell_name_storage + value_storage
                 start_index = index
-
-    def get_collection_name(self):
-        """Returns collection name"""
-        return 'cell_metadata'
-
-    def get_subcollection_name(self):
-        """Returns sub-collection name"""
-        return 'data'
 
     def store_validation_issue(self, type, category, msg, associated_info=None):
         """Store validation issues in proper arrangement

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -24,7 +24,7 @@ class Clusters(IngestFiles):
         # Second line in cluster is metadata_type
         self.metadata_types = self.get_next_line(increase_line_count=False)
         self.source_file_type = "cluster"
-        self.has_z = "z" or "Z" in self.header
+        self.has_z = True if ("z" in self.header or "Z" in self.header) else False
         self.cell_annotations = self.create_cell_annotations_field()
         # TODO: Populate the cell_annotations array when pandas is implemented
         self.top_level_doc = {

--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -159,6 +159,7 @@ class IngestFiles:
         while True:
             try:
                 row = next(self.file)
+                self.amount_of_lines += 1
                 return row
             except StopIteration:
                 break


### PR DESCRIPTION
[PR 25](https://github.com/broadinstitute/scp-ingest-pipeline/pulls?q=is%3Apr+is%3Aclosed) introduced some bugs into master. Particularly,  the "points", "cluster_type" field values in the cluster model were being populated incorrectly. Also, the document and subdocument names needed to be swapped around. This PR provides quick fixes.  