### PR TITLE
pre-commit hooks expect git-secrets [SCP-1905]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,21 @@ repos:
         language: system
         types: [python]
         stages: [push]
+    -   id: git-secrets pre-commit
+        name: git-secrets (pre-commit/push hook)
+        description: git-secrets scans commits to prevent secrets being committed -- for FISMA compliance. This runs it as a pre-commit hook.
+        entry: git-secrets --pre_commit_hook --
+        language: system
+        stages: [commit, push]
+    -   id: git-secrets commit-msg
+        name: git-secrets (commit-msg hook)
+        description: git-secrets scans commits to prevent secrets being committed -- for FISMA compliance. This runs it as a commit-msg hook.
+        entry: git-secrets --commit_msg_hook --
+        language: system
+        stages: [commit-msg]
+    -   id: git-secrets prepare-commit-msg
+        name: git-secrets (prepare-commit-msg hook)
+        description: git-secrets scans commits to prevent secrets being committed -- for FISMA compliance. This runs it as a prepare-commit-msg hook.
+        entry: git-secrets --prepare_commit_msg_hook --
+        language: system
+        stages: [prepare-commit-msg]


### PR DESCRIPTION
This integrates the existing hook setup (which uses the 'pre-commit' framework) with the pre-commit functionality we would expect from git-secrets. See https://github.com/broadinstitute/single_cell_portal_configs/tree/sl-git-secrets/developer-setup/git-secrets for more context.