### PR TITLE
Provide metadata convention in public bucket [SCP-1994]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get -y update && \
   apt -y install python3-pip
 
 # Set cleaner defaults (`alias` fails)
-RUN ln -s /usr/bin/python3 /usr/bin/python & \
-    ln -s /usr/bin/pip3 /usr/bin/pip
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+  ln -s /usr/bin/pip3 /usr/bin/pip
 
 # Copy contents of this repo into the Docker image
 # (See .Dockerignore for omitted files)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile for SCP Ingest Service
+# Dockerfile for SCP Ingest Pipeline
 #
 # PREREQUISITES
 # Run the following command to register gcloud as a Docker credential helper:
@@ -29,12 +29,12 @@ RUN ln -s /usr/bin/python3 /usr/bin/python && \
 
 # Copy contents of this repo into the Docker image
 # (See .Dockerignore for omitted files)
-COPY . scp-ingest-service
+COPY . scp-ingest-pipeline
 
-WORKDIR /scp-ingest-service
+WORKDIR /scp-ingest-pipeline
 
 # Install Python dependencies
 RUN pip install -r requirements.txt
 
-WORKDIR /scp-ingest-service/ingest
+WORKDIR /scp-ingest-pipeline/ingest
 CMD ["python", "ingest.py", "--help"]

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -60,7 +60,7 @@ EXPRESSION_FILE_TYPES = ["dense", "mtx", "loom"]
 
 class IngestPipeline(object):
     # File location for metadata json convention
-    JSON_CONVENTION = 'gs://broad-singlecellportal-jlchang-public/AMC_v1.1.3.json'
+    JSON_CONVENTION = 'gs://broad-singlecellportal-public/AMC_v1.1.3.json'
 
     def __init__(
         self,
@@ -544,6 +544,9 @@ def main() -> None:
     else:
         if status_cell_metadata > 0 and ingest.cell_metadata.is_remote_file:
             ingest.delocalize_error_file()
+        # PAPI jobs failing metadata validation against convention report 
+        #   "unexpected exit status 65 was not ignored"
+        # EX_DATAERR (65) The input data was incorrect in some way.
         sys.exit(os.EX_DATAERR)
 
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -544,7 +544,7 @@ def main() -> None:
     else:
         if status_cell_metadata > 0 and ingest.cell_metadata.is_remote_file:
             ingest.delocalize_error_file()
-        # PAPI jobs failing metadata validation against convention report 
+        # PAPI jobs failing metadata validation against convention report
         #   "unexpected exit status 65 was not ignored"
         # EX_DATAERR (65) The input data was incorrect in some way.
         sys.exit(os.EX_DATAERR)

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -60,7 +60,7 @@ EXPRESSION_FILE_TYPES = ["dense", "mtx", "loom"]
 
 class IngestPipeline(object):
     # File location for metadata json convention
-    JSON_CONVENTION = 'gs://fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/metadata_conventions/AMC_v1.1.3/AMC_v1.1.3.json'
+    JSON_CONVENTION = 'gs://broad-singlecellportal-jlchang-public/AMC_v1.1.3.json'
 
     def __init__(
         self,


### PR DESCRIPTION
This PR unblocks SCP-1944, SCP-1941 and other tickets in progress by:

- correcting a typo in the dockerfile so calls to python will succeed
- making metadata convention available in a public bucket in SCP prod environment
- pointing `ingest_pipeline.py` to use the newly available convention file
- also, update `scp-ingest-service` in dockerfile to `scp-ingest-pipeline`

This fulfills [SCP-1994](https://broadworkbench.atlassian.net/browse/SCP-1994)