### PR TITLE
Write convention metadata to BigQuery [SCP-1941]

### DIFF
--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -9,7 +9,13 @@ Must have python 3.6 or higher.
 
 import abc
 import pandas as pd  # NOqa: F821
-from ingest_files import IngestFiles
+
+try:
+    # Used when importing internally and in tests
+    from ingest_files import IngestFiles
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .ingest_files import IngestFiles
 
 
 class Annotations(IngestFiles):

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -12,9 +12,16 @@ from typing import Dict, Generator, List, Tuple, Union  # noqa: F401
 from dataclasses import dataclass
 from mypy_extensions import TypedDict
 import ntpath
-from annotations import Annotations
 import collections
-from ingest_files import DataArray
+
+try:
+    # Used when importing internally and in tests
+    from annotations import Annotations
+    from ingest_files import DataArray
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .annotations import Annotations
+    from .ingest_files import DataArray
 
 
 class CellMetadata(Annotations):

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -48,15 +48,27 @@ from pymongo import MongoClient
 from mtx import Mtx
 from google.cloud import storage
 
-# from ingest_files import IngestFiles
-from subsample import SubSample
-from loom import Loom
-from ingest_files import IngestFiles
-from validation.validate_metadata import (
-    validate_input_metadata,
-    report_issues,
-    write_metadata_to_bq,
-)
+try:
+    # Used when importing internally and in tests
+    from ingest_files import IngestFiles
+    from subsample import SubSample
+    from loom import Loom
+    from validation.validate_metadata import (
+        validate_input_metadata,
+        report_issues,
+        write_metadata_to_bq,
+    )
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .ingest_files import IngestFiles
+    from .subsample import SubSample
+    from .loom import Loom
+    from .validation.validate_metadata import (
+        validate_input_metadata,
+        report_issues,
+        write_metadata_to_bq,
+    )
+
 
 # Ingest file types
 EXPRESSION_FILE_TYPES = ["dense", "mtx", "loom"]

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -539,24 +539,25 @@ def validate_arguments(parsed_args):
             "must include .genes.tsv, and .barcodes.tsv files. See --help for "
             "more information"
         )
-    if (parsed_args.bq_dataset is not None and parsed_args.bq_table is None) or (
-        parsed_args.bq_dataset is None and parsed_args.bq_table is not None
-    ):
-        raise ValueError(
-            'Missing argument: --bq_dataset and --bq_table are both required for BigQuery upload.'
-        )
-    if parsed_args.bq_dataset is not None and not bq_dataset_exists(
-        parsed_args.bq_dataset
-    ):
-        raise ValueError(
-            f' Invalid argument: {parsed_args.bq_dataset} is not a valid BigQuery dataset.'
-        )
-    if parsed_args.bq_table is not None and not bq_table_exists(
-        parsed_args.bq_dataset, parsed_args.bq_table
-    ):
-        raise ValueError(
-            f' Invalid argument: {parsed_args.bq_table} is not a valid BigQuery table.'
-        )
+    if "ingest_cell_metadata" in parsed_args:
+        if (parsed_args.bq_dataset is not None and parsed_args.bq_table is None) or (
+            parsed_args.bq_dataset is None and parsed_args.bq_table is not None
+        ):
+            raise ValueError(
+                'Missing argument: --bq_dataset and --bq_table are both required for BigQuery upload.'
+            )
+        if parsed_args.bq_dataset is not None and not bq_dataset_exists(
+            parsed_args.bq_dataset
+        ):
+            raise ValueError(
+                f' Invalid argument: {parsed_args.bq_dataset} is not a valid BigQuery dataset.'
+            )
+        if parsed_args.bq_table is not None and not bq_table_exists(
+            parsed_args.bq_dataset, parsed_args.bq_table
+        ):
+            raise ValueError(
+                f' Invalid argument: {parsed_args.bq_table} is not a valid BigQuery table.'
+            )
 
 
 def main() -> None:

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -619,15 +619,18 @@ def main() -> None:
     if len(status) > 0:
         if all(i < 1 for i in status):
             sys.exit(os.EX_OK)
-    if status_cell_metadata is not None:
-        if status_cell_metadata > 0 and ingest.cell_metadata.is_remote_file:
-            ingest.delocalize_error_file()
-            # PAPI jobs failing metadata validation against convention report
-            #   "unexpected exit status 65 was not ignored"
-            # EX_DATAERR (65) The input data was incorrect in some way.
-            sys.exit(os.EX_DATAERR)
     else:
-        sys.exit(1)
+        if status_cell_metadata is not None:
+            if status_cell_metadata > 0 and ingest.cell_metadata.is_remote_file:
+                ingest.delocalize_error_file()
+                # PAPI jobs failing metadata validation against convention report
+                # will have "unexpected exit status 65 was not ignored"
+                # EX_DATAERR (65) The input data was incorrect in some way.
+                # note that failure to load to MongoDB also triggers this error
+                sys.exit(os.EX_DATAERR)
+            if status_metadata_bq is not None:
+                if status_metadata_bq > 0:
+                    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/scratch_query/get_bq_job_info.py
+++ b/scripts/scratch_query/get_bq_job_info.py
@@ -1,0 +1,48 @@
+"""Upload NDJSON file to BigQuery
+
+DESCRIPTION
+This CLI takes a local NDJSON file and appends it to an existing bigquery table.
+(reference: https://cloud.google.com/bigquery/docs/managing-jobs
+https://cloud.google.com/bigquery/troubleshooting-errors)
+
+SYNTAX
+$ python query_bq_job.py job_id
+
+EXAMPLE
+$ python query_bq_job.py d30e45f5-da00-4dc5-8c52-539f67274725
+
+"""
+
+import argparse
+from google.cloud import bigquery
+
+
+def create_parser():
+    """
+    Command Line parser for serialize_convention
+
+    Input: metadata convention tsv file
+    """
+    # create the argument parser
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('job_id', help='bigqury job ID')
+    return parser
+
+
+if __name__ == '__main__':
+    args = create_parser().parse_args()
+    job_id = args.job_id
+    client = bigquery.Client()
+
+    location = 'us'
+
+    job = client.get_job(job_id, location=location)
+
+    print("Details for job {} running in {}:".format(job_id, location))
+    print(
+        "\tType: {}\n\tState: {}\n\tCreated: {}".format(
+            job.job_type, job.state, job.created, job.status
+        )
+    )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         'google-cloud-firestore',
         'google-cloud-storage',
+        'google-cloud-bigquery',
         'requests',
         'numpy',
         'scipy',


### PR DESCRIPTION
This PR leverages existing code for metadata validation to generate an NDJSON file suitable for upload to BigQuery.

To upload metadata, ingest-pipeline.py expects:
• the `--validate-convention` flag
• a valid BigQuery dataset name for the GCP project in the runtime environment
• a valid BigQuery table in the provided BigQuery dataset

`--validate-convention` without `--bq-dataset` and `--bq-table` will validate without uploading convention metadata to BigQuery.

This PR fulfills [SCP-1941](https://broadworkbench.atlassian.net/browse/SCP-1941)