### PR TITLE
Adjust imports and packaging for public CLI [SCP-1913]

### DIFF
--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -10,6 +10,7 @@ except ImportError:
     from .ingest_files import DataArray
     from .annotations import Annotations
 
+
 @dataclass
 class DomainRanges(TypedDict):
     x: List

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -2,9 +2,13 @@ from typing import Dict, Generator, List, Tuple, Union  # noqa: F401
 from dataclasses import dataclass
 from mypy_extensions import TypedDict
 
-from ingest_files import DataArray
-from annotations import Annotations
-
+try:
+    from ingest_files import DataArray
+    from annotations import Annotations
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .ingest_files import DataArray
+    from .annotations import Annotations
 
 @dataclass
 class DomainRanges(TypedDict):

--- a/ingest/dense.py
+++ b/ingest/dense.py
@@ -17,6 +17,7 @@ except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .expression_files import GeneExpression
 
+
 class Dense(GeneExpression):
     ALLOWED_FILE_TYPES = ["text/csv", "text/plain", "text/tab-separated-values"]
 

--- a/ingest/dense.py
+++ b/ingest/dense.py
@@ -11,8 +11,11 @@ Must have python 3.6 or higher.
 import collections
 from typing import List  # noqa: F401
 
-from expression_files import GeneExpression
-
+try:
+    from expression_files import GeneExpression
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .expression_files import GeneExpression
 
 class Dense(GeneExpression):
     ALLOWED_FILE_TYPES = ["text/csv", "text/plain", "text/tab-separated-values"]

--- a/ingest/expression_files.py
+++ b/ingest/expression_files.py
@@ -19,6 +19,7 @@ except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .ingest_files import IngestFiles, DataArray
 
+
 class GeneExpression(IngestFiles):
     __metaclass__ = abc.ABCMeta
     COLLECTION_NAME = 'genes'

--- a/ingest/expression_files.py
+++ b/ingest/expression_files.py
@@ -7,13 +7,17 @@ files.
 PREREQUISITES
 Must have python 3.6 or higher.
 """
-from ingest_files import IngestFiles, DataArray
 import abc
 from dataclasses import dataclass
 from mypy_extensions import TypedDict
 from typing import List  # noqa: F401
 import ntpath
 
+try:
+    from ingest_files import IngestFiles, DataArray
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .ingest_files import IngestFiles, DataArray
 
 class GeneExpression(IngestFiles):
     __metaclass__ = abc.ABCMeta

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -41,11 +41,7 @@ import sys
 import json
 import os
 
-from cell_metadata import CellMetadata
-from clusters import Clusters
-from dense import Dense
 from pymongo import MongoClient
-from mtx import Mtx
 from google.cloud import storage
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
@@ -60,6 +56,10 @@ try:
         report_issues,
         write_metadata_to_bq,
     )
+    from cell_metadata import CellMetadata
+    from clusters import Clusters
+    from dense import Dense
+    from mtx import Mtx
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .ingest_files import IngestFiles
@@ -70,6 +70,10 @@ except ImportError:
         report_issues,
         write_metadata_to_bq,
     )
+    from .cell_metadata import CellMetadata
+    from .clusters import Clusters
+    from .dense import Dense
+    from .mtx import Mtx
 
 
 # Ingest file types

--- a/ingest/mtx.py
+++ b/ingest/mtx.py
@@ -14,7 +14,12 @@ Must have python 3.6 or higher.
 from typing import Dict, Generator, List, Tuple, Union  # noqa: F401
 import collections
 import scipy.io
-from expression_files import GeneExpression
+
+try:
+    from expression_files import GeneExpression
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .expression_files import GeneExpression
 
 
 class Mtx(GeneExpression):

--- a/ingest/subsample.py
+++ b/ingest/subsample.py
@@ -2,8 +2,14 @@ import copy
 from typing import List, Tuple  # noqa: F401
 
 import numpy as np
-from annotations import Annotations
-from clusters import Clusters
+
+try:
+    from annotations import Annotations
+    from clusters import Clusters
+except ImportError:
+    # Used when importing as external package, e.g. imports in single_cell_portal code
+    from .annotations import Annotations
+    from .clusters import Clusters
 
 
 class SubSample(Annotations):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'dataclasses',
         'mypy_extensions',
         'pymongo',
-        'loompy'
+        'loompy',
     ],
     packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ setup(
         'colorama',
         'dataclasses',
         'mypy_extensions',
+        'pymongo',
+        'loompy'
     ],
     packages=find_packages(),
 )


### PR DESCRIPTION
This adjusts imports and packaging to ensure metadata validation code in Ingest Pipeline can be used by the public CLI.  Such adjustments are needed by broadinstitute/single_cell_portal#84; see there for more context.

This satisfies SCP-1913.