### PR TITLE
Ingest R formatted gene expression files

### DIFF
--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -22,16 +22,15 @@ except ImportError:
 class Annotations(IngestFiles):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(
-        self, file_path, allowed_file_types, study_id=None, study_file_id=None
-    ):
-        IngestFiles.__init__(
-            self, file_path, allowed_file_types, open_as='dataframe', header=[0, 1]
+    def __init__(self, file_path, study_id=None, study_file_id=None):
+        IngestFiles.__init__(self, file_path, self.ALLOWED_FILE_TYPES)
+        self.study_id = ObjectId(study_id)
+        self.study_file_id = ObjectId(study_file_id)
+        self.file, self.file_handle = self.open_file(
+            file_path, open_as='dataframe', header=[0, 1]
         )
         self.headers = self.file.columns.get_level_values(0)
         self.annot_types = self.file.columns.get_level_values(1)
-        self.study_id = ObjectId(study_id)
-        self.study_file_id = ObjectId(study_file_id)
 
     @abc.abstractmethod
     def transform(self):

--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -98,7 +98,9 @@ class Annotations(IngestFiles):
                 "numeric", axis=1, level=1, drop_level=False
             ).columns.tolist()
             # TODO perform replace
-            self.file[numeric_columns] = self.file[numeric_columns].round(3).astype(float)
+            self.file[numeric_columns] = (
+                self.file[numeric_columns].round(3).astype(float)
+            )
 
     def store_validation_issue(self, type, category, msg, associated_info=None):
         """Store validation issues in proper arrangement

--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -22,15 +22,24 @@ except ImportError:
 class Annotations(IngestFiles):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, file_path, study_id=None, study_file_id=None):
-        IngestFiles.__init__(self, file_path, self.ALLOWED_FILE_TYPES)
-        self.study_id = ObjectId(study_id)
-        self.study_file_id = ObjectId(study_file_id)
+    def __init__(
+        self, file_path, allowed_file_types, study_id=None, study_file_id=None
+    ):
+        IngestFiles.__init__(self, file_path, allowed_file_types)
+        if study_id is not None:
+            self.study_id = ObjectId(study_id)
+        if study_file_id is not None:
+            self.study_file_id = ObjectId(study_file_id)
         self.file, self.file_handle = self.open_file(
             file_path, open_as='dataframe', header=[0, 1]
         )
         self.headers = self.file.columns.get_level_values(0)
         self.annot_types = self.file.columns.get_level_values(1)
+
+    def reset_file(self):
+        self.file, self.file_handle = self.open_file(
+            self.file_path, open_as='dataframe', header=[0, 1]
+        )
 
     @abc.abstractmethod
     def transform(self):

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -39,7 +39,9 @@ class CellMetadata(Annotations):
     ):
 
         self.study_accession = kwargs.pop("study_accession")
-        Annotations.__init__(self, file_path, study_id, study_file_id)
+        Annotations.__init__(
+            self, file_path, self.ALLOWED_FILE_TYPES, study_id, study_file_id
+        )
         self.cell_names = []
         # lambda below initializes new key with nested dictionary as value and avoids KeyError
         self.issues = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -39,10 +39,7 @@ class CellMetadata(Annotations):
     ):
 
         self.study_accession = kwargs.pop("study_accession")
-        Annotations.__init__(
-            self, file_path, self.ALLOWED_FILE_TYPES, study_id, study_file_id
-        )
-        self.file_path = file_path
+        Annotations.__init__(self, file_path, study_id, study_file_id)
         self.cell_names = []
         # lambda below initializes new key with nested dictionary as value and avoids KeyError
         self.issues = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -57,7 +57,9 @@ class Clusters(Annotations):
         *,
         domain_ranges: Dict = None,
     ):
-        Annotations.__init__(self, file_path, study_id, study_file_id)
+        Annotations.__init__(
+            self, file_path, self.ALLOWED_FILE_TYPES, study_id, study_file_id
+        )
         self.determine_coordinates_and_cell_names()
         self.source_file_type = "cluster"
         self.cluster_type = (

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -57,9 +57,7 @@ class Clusters(Annotations):
         *,
         domain_ranges: Dict = None,
     ):
-        Annotations.__init__(
-            self, file_path, self.ALLOWED_FILE_TYPES, study_id, study_file_id
-        )
+        Annotations.__init__(self, file_path, study_id, study_file_id)
         self.determine_coordinates_and_cell_names()
         self.source_file_type = "cluster"
         self.cluster_type = (

--- a/ingest/dense.py
+++ b/ingest/dense.py
@@ -38,13 +38,11 @@ class Dense(GeneExpression, IngestFiles):
     def preprocess(self):
         csv_file, open_file_object = self.open_file(self.file_path)
         header = next(csv_file)
-        print(header)
         first_row = next(csv_file)
         dtypes = {'GENE': object}
 
         # # Remove white spaces and quotes
         header = [col_name.strip().strip('\"') for col_name in header]
-        print(header)
         # See if R formatted file
         if (header[-1] == '') and (header[0].upper() != 'GENE'):
             header.insert(0, 'GENE')
@@ -55,8 +53,6 @@ class Dense(GeneExpression, IngestFiles):
             header[0] = header[0].upper()
         # Set dtype for expression values to floats
         dtypes.update({cell_name: 'float' for cell_name in header[1:]})
-
-        # print(dtypes)
         self.df = self.open_file(
             self.file_path,
             open_as='dataframe',
@@ -65,7 +61,6 @@ class Dense(GeneExpression, IngestFiles):
             dtype=dtypes,
             open_file_object=open_file_object,
         )[0]
-        print(self.df)
 
     def transform(self):
         """Transforms dense matrix into firestore data model for genes.

--- a/ingest/dense.py
+++ b/ingest/dense.py
@@ -13,40 +13,57 @@ from typing import List  # noqa: F401
 
 try:
     from expression_files import GeneExpression
+    from ingest_files import IngestFiles
 
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .expression_files import GeneExpression
+    from .ingest_files import IngestFiles
 
 
-class Dense(GeneExpression):
+class Dense(GeneExpression, IngestFiles):
     ALLOWED_FILE_TYPES = ["text/csv", "text/plain", "text/tab-separated-values"]
 
     def __init__(self, file_path, study_file_id, study_id, **kwargs):
         GeneExpression.__init__(
-            self,
-            file_path,
-            study_file_id,
-            study_id,
-            allowed_file_types=self.ALLOWED_FILE_TYPES,
-            open_as='dataframe',
+            self, file_path, study_file_id, study_id,
         )
-        # Remove from dictionary any keys that have value=None
+        IngestFiles.__init__(
+            self, file_path, allowed_file_types=self.ALLOWED_FILE_TYPES
+        )
         self.matrix_params = kwargs
-        # Remove trailing white spaces, and quotes from column names
-        self.file.rename(
-            columns=lambda x: x.strip().strip('\"').strip('\'').strip('\"'),
-            inplace=True,
-        )
+
+        self.preprocess()
+
+    def preprocess(self):
+        self.open_file_object = self.open_file(self.file_path)[0]
+        header = next(open_file_object)
+        first_row = next(open_file_object)
+        dtypes = {'GENE': object}
+
+        # # Remove white spaces and quotes
+        header = [col_name.strip().strip('\"') for col_name in header]
+        # See if R formatted file
+        if (header[-1] == '') and (header[0].upper() != 'GENE'):
+            header.insert(0, 'GENE')
+            # Although the last column in the header is empty, python treats it
+            # as an empty string,[ ..., ""]
+            header = header[0:-1]
+        else:
+            header[0] = header[0].upper()
+        # Set dtype for expression values to floats
+        dtypes.update({cell_name: 'float' for cell_name in header[1:]})
+
+        # print(dtypes)
+        self.df = self.open_pandas(self.df_path, names=header, skiprows=1, dtype=dtypes)
 
     def transform(self):
         """Transforms dense matrix into firestore data model for genes.
         """
         # Holds gene name and gene model for a single gene
         GeneModel = collections.namedtuple('Gene', ['gene_name', 'gene_model'])
-        for gene in self.file['GENE']:
-            # Remove white spaces and quotes
-            formatted_gene_name = gene.strip().strip('\"').strip('\'').strip('\"')
+        for gene in self.df['GENE']:
+            formatted_gene_name = gene.strip().strip('\"')
             self.info_logger.info(
                 f'Transforming gene :{gene}', extra=self.extra_log_params
             )
@@ -75,9 +92,9 @@ class Dense(GeneExpression):
     ):
         """Creates data array for expression, gene, and cell values."""
         input_args = locals()
-        gene_df = self.file[self.file['GENE'] == unformatted_gene_name]
+        gene_df = self.df[self.df['GENE'] == unformatted_gene_name]
         # Get list of cell names
-        cells = self.file.columns.tolist()[1:]
+        cells = self.df.columns.tolist()[1:]
         if create_cell_data_array:
             self.info_logger.info(
                 f'Creating cell data array for gene : {gene_name}',
@@ -87,10 +104,7 @@ class Dense(GeneExpression):
 
         # Get row of expression values for gene
         # Round expression values to 3 decimal points
-        # Insure data type of float for expression values
-        cells_and_expression_vals = (
-            gene_df[cells].round(3).astype(float).to_dict('records')[0]
-        )
+        cells_and_expression_vals = gene_df[cells].round(3).to_dict('records')[0]
         # Filter out expression values = 0
         cells_and_expression_vals = dict(
             filter(lambda k_v: k_v[1] > 0, cells_and_expression_vals.items())
@@ -124,4 +138,4 @@ class Dense(GeneExpression):
         Returns:
             None
         """
-        self.file.close()
+        self.df.close()

--- a/ingest/dense.py
+++ b/ingest/dense.py
@@ -36,13 +36,15 @@ class Dense(GeneExpression, IngestFiles):
         self.preprocess()
 
     def preprocess(self):
-        self.open_file_object = self.open_file(self.file_path)[0]
-        header = next(open_file_object)
-        first_row = next(open_file_object)
+        csv_file, open_file_object = self.open_file(self.file_path)
+        header = next(csv_file)
+        print(header)
+        first_row = next(csv_file)
         dtypes = {'GENE': object}
 
         # # Remove white spaces and quotes
         header = [col_name.strip().strip('\"') for col_name in header]
+        print(header)
         # See if R formatted file
         if (header[-1] == '') and (header[0].upper() != 'GENE'):
             header.insert(0, 'GENE')
@@ -55,7 +57,15 @@ class Dense(GeneExpression, IngestFiles):
         dtypes.update({cell_name: 'float' for cell_name in header[1:]})
 
         # print(dtypes)
-        self.df = self.open_pandas(self.df_path, names=header, skiprows=1, dtype=dtypes)
+        self.df = self.open_file(
+            self.file_path,
+            open_as='dataframe',
+            names=header,
+            skiprows=1,
+            dtype=dtypes,
+            open_file_object=open_file_object,
+        )[0]
+        print(self.df)
 
     def transform(self):
         """Transforms dense matrix into firestore data model for genes.

--- a/ingest/dense.py
+++ b/ingest/dense.py
@@ -38,7 +38,6 @@ class Dense(GeneExpression, IngestFiles):
     def preprocess(self):
         csv_file, open_file_object = self.open_file(self.file_path)
         header = next(csv_file)
-        first_row = next(csv_file)
         dtypes = {'GENE': object}
 
         # # Remove white spaces and quotes

--- a/ingest/expression_files.py
+++ b/ingest/expression_files.py
@@ -16,22 +16,22 @@ import logging
 from bson.objectid import ObjectId
 
 try:
-    from ingest_files import IngestFiles, DataArray
+    from ingest_files import DataArray
     from monitor import setup_logger, log
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
-    from .ingest_files import IngestFiles, DataArray
+    from .ingest_files import DataArray
     from .monitor import setup_logger, log
 
 
-error_logger = setup_logger(__name__ + '_errors', 'errors.txt', level=logging.ERROR)
+error_logger = setup_logger(__name__ + "_errors", "errors.txt", level=logging.ERROR)
 my_debug_logger = log(error_logger)
 
 
-class GeneExpression(IngestFiles):
+class GeneExpression:
     __metaclass__ = abc.ABCMeta
-    COLLECTION_NAME = 'genes'
-    info_logger = setup_logger(__name__, 'info.txt')
+    COLLECTION_NAME = "genes"
+    info_logger = setup_logger(__name__, "info.txt")
 
     @dataclass
     class Model(TypedDict):
@@ -43,22 +43,13 @@ class GeneExpression(IngestFiles):
         gene_id: str = None
 
     def __init__(
-        self,
-        file_path: str,
-        study_id: str,
-        study_file_id: str,
-        allowed_file_types: str = None,
-        open_as=None,
+        self, file_path: str, study_id: str, study_file_id: str,
     ):
         self.study_id = ObjectId(study_id)
         self.study_file_id = ObjectId(study_file_id)
         self.head, self.tail = ntpath.split(file_path)
         self.cluster_name = self.tail or ntpath.basename(self.head)
-        if open_as is not None:
-            IngestFiles.__init__(
-                self, file_path, allowed_file_types, open_as='dataframe'
-            )
-        self.extra_log_params = {'study_id': self.study_id, 'duration': None}
+        self.extra_log_params = {"study_id": self.study_id, "duration": None}
 
     @abc.abstractmethod
     def transform(self):
@@ -74,11 +65,11 @@ class GeneExpression(IngestFiles):
         """Sets DataArray for cells that were observed in an
         expression matrix."""
         return DataArray(
-            f'{self.cluster_name} Cells',
+            f"{self.cluster_name} Cells",
             self.cluster_name,
-            'cells',
+            "cells",
             values,
-            'Study',
+            "Study",
             linear_data_id,
             self.study_id,
             self.study_file_id,
@@ -92,11 +83,11 @@ class GeneExpression(IngestFiles):
         expression for a gene. """
 
         return DataArray(
-            f'{name} Cells',
+            f"{name} Cells",
             self.cluster_name,
-            'cells',
+            "cells",
             values,
-            'Gene',
+            "Gene",
             linear_data_id,
             self.study_id,
             self.study_file_id,
@@ -109,11 +100,11 @@ class GeneExpression(IngestFiles):
         significant (i.e. non-zero) expression values for a gene. """
 
         return DataArray(
-            f'{name} Expression',
+            f"{name} Expression",
             self.cluster_name,
-            'expression',
+            "expression",
             values,
-            'Gene',
+            "Gene",
             linear_data_id,
             self.study_id,
             self.study_file_id,

--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -208,14 +208,14 @@ class IngestFiles:
         # See if file type is allowed
         file_type = self.get_file_type(file_path)[0]
         self.info_logger.info(
-            f"opening {file_path} as: {self.file_type}",
+            f"opening {file_path} as: {file_type}",
             extra={"study_id": None, "duration": None},
         )
         if file_type in self.allowed_file_types:
             # Return file object and type
             if open_as is None:
                 return (
-                    file_connections.get(file_type)(open_file, kwargs),
+                    file_connections.get(file_type)(open_file, **kwargs),
                     open_file,
                 )
             else:

--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -144,13 +144,11 @@ class IngestFiles:
             open_file = open(file_path, 'rt', encoding="utf-8-sig")
         return open_file, file_path
 
-    def reset_file(self, start_point, open_as=None):
+    def reset_file(self, file_path, start_point, open_as=None):
         """Restart file reader at point that's equal to start_point.
         Method is used in cases where a file may need to be read multiple times"""
 
-        self.file, self.file_handle = self.open_file(
-            self.file_path, start_point=start_point, open_as=open_as
-        )
+        return self.open_file(file_path, start_point=start_point, open_as=open_as)
 
     @staticmethod
     def delocalize_file(
@@ -202,7 +200,7 @@ class IngestFiles:
         }
         open_file, file_path = self.resolve_path(file_path)
         if start_point != 0:
-            self.amount_of_lines = start
+            self.amount_of_lines = 0
             for i in range(start_point):
                 open_file.readline()
         # See if file type is allowed
@@ -287,7 +285,6 @@ class IngestFiles:
             open_file_object.seek(0)
             csv_dialect = csv.Sniffer().sniff(open_file_object.read(1024))
             csv_dialect.skipinitialspace = True
-            print(csv_dialect.__dict__)
             return pd.read_csv(file_path, dialect=csv_dialect, **kwargs)
 
         else:

--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -26,9 +26,9 @@ except ImportError:
 @dataclass
 class DataArray:
     MAX_ENTRIES = 100_000
-    COLLECTION_NAME = 'data_arrays'
+    COLLECTION_NAME = "data_arrays"
     errors_logger = setup_logger(
-        __name__ + '_errors', 'errors.txt', level=logging.ERROR
+        __name__ + "_errors", "errors.txt", level=logging.ERROR
     )
 
     def __init__(
@@ -57,15 +57,15 @@ class DataArray:
         self.study_id = study_id
         self.study_file_id = study_file_id
         # special case to override linear_data_id in case of 'Study' linear_data_type
-        if self.linear_data_type == 'Study':
+        if self.linear_data_type == "Study":
             self.linear_data_id = self.study_id
 
     def get_data_array(self):
         if len(self.values) > self.MAX_ENTRIES:
             values = self.values
             for i in range(0, len(self.values), self.MAX_ENTRIES):
-                self.__dict__['values']: values[i : i + self.MAX_ENTRIES]
-                self.__dict__['array_index']: i
+                self.__dict__["values"]: values[i : i + self.MAX_ENTRIES]
+                self.__dict__["array_index"]: i
                 yield self.__dict__
         else:
             yield self.__dict__
@@ -73,12 +73,11 @@ class DataArray:
 
 class IngestFiles:
     # General logger for class
-    info_logger = setup_logger(__name__, 'info.txt')
-    error_logger = setup_logger(__name__ + '_errors', 'errors.txt', level=logging.ERROR)
+    info_logger = setup_logger(__name__, "info.txt")
+    error_logger = setup_logger(__name__ + "_errors", "errors.txt", level=logging.ERROR)
 
-    def __init__(self, file_path, allowed_file_types, open_as=None, **file_kwargs):
+    def __init__(self, file_path, allowed_file_types):
         self.file_path = file_path
-        self.file_kwargs = file_kwargs
         # File is remote (in GCS bucket) when running via PAPI,
         # and typically local when developing
         self.is_remote_file = IngestFiles.is_remote_file(file_path)
@@ -87,7 +86,6 @@ class IngestFiles:
         self.verify_file_exists(file_path)
 
         self.allowed_file_types = allowed_file_types
-        self.file_type, self.file, self.file_handle = self.open_file(file_path, open_as)
         # Keeps tracks of lines parsed
         self.amount_of_lines = 0
 
@@ -102,7 +100,7 @@ class IngestFiles:
         blob.download_to_filename(destination)
         self.info_logger.info(
             f"{file_path} downloaded to {destination}.",
-            extra={'study_id': None, 'duration': None},
+            extra={"study_id": None, "duration": None},
         )
         return destination
 
@@ -141,16 +139,16 @@ class IngestFiles:
             self.local_file_path = file_path
         # Remove BOM with encoding ='utf - 8 - sig'
         if self.is_gzip_file:
-            open_file = gzip.open(file_path, 'rt', encoding='utf-8-sig')
+            open_file = gzip.open(file_path, "rt", encoding="utf-8-sig")
         else:
-            open_file = open(file_path, encoding="utf-8-sig")
+            open_file = open(file_path, 'rt', encoding="utf-8-sig")
         return open_file, file_path
 
     def reset_file(self, start_point, open_as=None):
         """Restart file reader at point that's equal to start_point.
         Method is used in cases where a file may need to be read multiple times"""
 
-        self.file_type, self.file, self.file_handle = self.open_file(
+        self.file, self.file_handle = self.open_file(
             self.file_path, start_point=start_point, open_as=open_as
         )
 
@@ -165,11 +163,11 @@ class IngestFiles:
             bucket_destination: path to google bucket (ie. parse_logs/{study_file_id}/errors.txt)
 
         """
-        info_logger = setup_logger(__name__, 'info.txt')
+        info_logger = setup_logger(__name__, "info.txt")
         error_logger = setup_logger(
-            __name__ + '_errors', 'errors.txt', level=logging.ERROR
+            __name__ + "_errors", "errors.txt", level=logging.ERROR
         )
-        extra_log_params = {'study_id': study_id, 'duration': None}
+        extra_log_params = {"study_id": study_id, "duration": None}
         if IngestFiles.is_remote_file(file_path):
             try:
                 path_segments = file_path[5:].split("/")
@@ -179,62 +177,55 @@ class IngestFiles:
                 blob = bucket.blob(bucket_destination)
                 blob.upload_from_filename(file_to_delocalize)
                 info_logger.info(
-                    f'File {file_to_delocalize} uploaded to {bucket_destination}.',
+                    f"File {file_to_delocalize} uploaded to {bucket_destination}.",
                     extra=extra_log_params,
                 )
             except Exception as e:
                 error_logger.error(
-                    f'File {file_to_delocalize} not uploaded to {bucket_destination}.',
+                    f"File {file_to_delocalize} not uploaded to {bucket_destination}.",
                     extra=extra_log_params,
                 )
                 error_logger.error(e, extra=extra_log_params)
         else:
             error_logger.error(
-                'Cannot push to bucket. File is not remote', extra=extra_log_params
+                "Cannot push to bucket. File is not remote", extra=extra_log_params
             )
 
-    def open_file(self, file_path, open_as=None, header=None, start_point: int = 0):
-        """ Opens txt, csv, or tsv formatted files"""
-        open_file, file_path = self.resolve_path(file_path)
-        if start_point != 0:
-            for i in range(start_point):
-                open_file.readline()
+    def open_file(self, file_path, open_as=None, start_point: int = 0, **kwargs):
+        """ Opens txt (txt is expected to be tsv or csv), csv, or tsv formatted files"""
         file_connections = {
-            "text/csv": self.open_csv(open_file),
-            "text/plain": open_file,
-            "application/json": open_file,
-            "text/tab-separated-values": self.open_tsv(open_file),
+            "text/csv": self.open_csv,
+            "text/plain": self.open_txt,
+            "application/json": self.open_file,
+            "text/tab-separated-values": self.open_tsv,
             "dataframe": self.open_pandas,
         }
-        # Check file type
+        open_file, file_path = self.resolve_path(file_path)
+        if start_point != 0:
+            self.amount_of_lines = start
+            for i in range(start_point):
+                open_file.readline()
+        # See if file type is allowed
         file_type = self.get_file_type(file_path)[0]
         self.info_logger.info(
-            f'opening {file_path} as: {file_type}',
-            extra={'study_id': None, 'duration': None},
+            f"opening {file_path} as: {self.file_type}",
+            extra={"study_id": None, "duration": None},
         )
-        # See if file type is allowed
         if file_type in self.allowed_file_types:
             # Return file object and type
             if open_as is None:
-                return file_type, file_connections.get(file_type), open_file
+                return (
+                    file_connections.get(file_type)(open_file, kwargs),
+                    open_file,
+                )
             else:
-                if self.is_remote_file:
-                    return (
-                        file_type,
-                        file_connections.get("dataframe")(
-                            open_file, self.local_file_path
-                        ),
-                        open_file,
-                    )
-                else:
-                    return (
-                        file_type,
-                        file_connections.get("dataframe")(open_file, file_path),
-                        open_file,
-                    )
+                return (
+                    file_connections.get(open_as)(file_path, **kwargs),
+                    open_file,
+                )
         else:
             raise ValueError(
-                f"Unsupported file format. Allowed file types are: {' '.join(self.allowed_file_type)}"
+                f"Unsupported file format. Allowed file types are: {' '.join(self.allowed_file_types)}"
             )
 
     # Inherited function
@@ -259,85 +250,72 @@ class IngestFiles:
         """Returns file type"""
         return mimetypes.guess_type(file_path)
 
-    def open_pandas(self, opened_file, file_path):
+    def open_txt(self, open_file_object):
+        """Method for opening txt files that are expected be tab
+        or comma delimited"""
+        # Determined if file is tsv or csv
+        csv_dialect = csv.Sniffer().sniff(open_file_object.read(1024))
+        csv_dialect.skipinitialspace = True
+        open_file_object.seek(0)
+        return csv.reader(open_file_object, self.csv_dialect)
+
+    def open_pandas(self, file_path, **kwargs):
         """Opens file as a dataframe """
-        opened_file.readline()
-        meta_data = opened_file.readline()
-        if meta_data.find("\t") != -1:
+        if self.file_type == "text/tab-separated-values":
             return pd.read_csv(
                 file_path,
                 sep="\t",
                 skipinitialspace=True,
-                quoting=csv.QUOTE_NONE,
-                **self.file_kwargs,
+                quoting=csv.QUOTE_NONNUMERIC,
+                **kwargs,
             )
-        elif meta_data.find(",") != -1:
+        elif self.file_type == "text/csv":
             return pd.read_csv(
                 file_path,
                 sep=",",
+                quotechar='"',
+                quoting=csv.QUOTE_NONNUMERIC,
                 skipinitialspace=True,
-                quoting=csv.QUOTE_NONE,
-                **self.file_kwargs,
+                escapechar='\\',
+                **kwargs,
             )
+        elif self.file_type == 'text/plain':
+            open_file_object.seek(0)
+            csv_dialect = csv.Sniffer().sniff(open_file_object.read(1024))
+            csv_dialect.skipinitialspace = True
+            return pd.read_csv(file_path, dialect=csv_dialect, **kwargs)
+
         else:
             raise ValueError("File must be tab or comma delimited")
 
     def open_csv(self, opened_file_object):
         """Opens csv file"""
         csv.register_dialect(
-            "csvDialect", delimiter=",", quoting=csv.QUOTE_ALL, skipinitialspace=True
+            "csvDialect",
+            delimiter=",",
+            quotechar='"',
+            quoting=csv.QUOTE_NONE,
+            skipinitialspace=True,
+            escapechar='\\',
         )
         return csv.reader(opened_file_object, dialect="csvDialect")
 
     def open_tsv(self, opened_file_object):
         """Opens tsv file"""
         csv.register_dialect(
-            "tsvDialect", delimiter="\t", quoting=csv.QUOTE_ALL, skipinitialspace=True
+            "tsvDialect",
+            delimiter="\t",
+            quoting=csv.QUOTE_NONNUMERIC,
+            skipinitialspace=True,
         )
         return csv.reader(opened_file_object, dialect="tsvDialect")
 
-    def extract_csv_or_tsv(self):
+    def extract_csv_or_tsv(self, file):
         """Extracts all rows from a csv or tsv file"""
         while True:
             try:
-                row = next(self.file)
+                row = next(file)
                 self.amount_of_lines += 1
                 return row
             except StopIteration:
                 break
-
-    def extract_txt(self):
-        """Extracts all lines from txt files
-
-        Returns:
-                next_row_revised : List[str]
-                    A single row from a txt file.
-        """
-        while True:
-            next_row = self.file.readline()
-            if not next_row:
-                break
-            self.amount_of_lines += 1
-            # Create array with no new line, commas, or tab characters
-            next_row_revised = self.split_line(
-                next_row.replace("\n", "").replace('"', "")
-            )
-            return next_row_revised
-
-    def get_next_line(self, *, increase_line_count=True, split_line=True):
-        """Returns a single line of txt, csv or tsv files"""
-
-        next_row = next(self.file)
-        # Increase counter for line extracted
-        if increase_line_count:
-            self.amount_of_lines += 1
-        elif self.file_type in ("text/csv", "text/tab-separated-values"):
-            # CSV and TSV files returns next lines as array split on tabs/commas
-            return next_row
-        elif self.file_type == "text/plain":
-            # Create array with no new line, commas, or tab characters
-            next_row_revised = next_row.replace("\n", "")
-            if split_line:
-                return self.split_line(next_row_revised)
-            else:
-                return next_row_revised

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -46,13 +46,11 @@ import re
 from pymongo import MongoClient
 from google.cloud import bigquery
 
-# import google.cloud.logging
+import google.cloud.logging
 from google.cloud.exceptions import NotFound
 from bson.objectid import ObjectId
 
 # from google.cloud.logging.resource import Resource
-
-# import logging
 
 try:
     # Used when importing internally and in tests
@@ -302,30 +300,30 @@ class IngestPipeline(object):
                 f"Attempting to load gene: {gene.gene_model['searchable_name']}",
                 extra=self.extra_log_params,
             )
-            if idx == 0:
-                status = self.load(
-                    self.matrix.COLLECTION_NAME,
-                    gene.gene_model,
-                    self.matrix.set_data_array,
-                    gene.gene_name,
-                    gene.gene_model['searchable_name'],
-                    {'create_cell_data_array': True},
-                )
-            else:
-                status = self.load(
-                    self.matrix.COLLECTION_NAME,
-                    gene.gene_model,
-                    self.matrix.set_data_array,
-                    gene.gene_name,
-                    gene.gene_model['searchable_name'],
-                )
-            if status != 0:
-                self.errors_logger.error(
-                    f'Loading gene name {gene.gene_name} failed. Exiting program',
-                    extra=self.extra_log_params,
-                )
-                return status
-        return status
+            # if idx == 0:
+            #     status = self.load(
+            #         self.matrix.COLLECTION_NAME,
+            #         gene.gene_model,
+            #         self.matrix.set_data_array,
+            #         gene.gene_name,
+            #         gene.gene_model['searchable_name'],
+            #         {'create_cell_data_array': True},
+            #     )
+            # else:
+            #     status = self.load(
+            #         self.matrix.COLLECTION_NAME,
+            #         gene.gene_model,
+            #         self.matrix.set_data_array,
+            #         gene.gene_name,
+            #         gene.gene_model['searchable_name'],
+            #     )
+            # if status != 0:
+            #     self.errors_logger.error(
+            #         f'Loading gene name {gene.gene_name} failed. Exiting program',
+            #         extra=self.extra_log_params,
+            #     )
+            #     return status
+        return 1
 
     @my_debug_logger()
     def ingest_cell_metadata(self):
@@ -684,6 +682,8 @@ def main() -> None:
                             'errors.txt',
                             f'parse_logs/{study_file_id}/errors.txt',
                         )
+                    # Need 1 argument that has a path to identify google bucket
+                    # Break after first argument
                     break
             if status_cell_metadata is not None:
                 if status_cell_metadata > 0 and ingest.cell_metadata.is_remote_file:

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -379,6 +379,7 @@ class IngestPipeline(object):
                 return status
         return status
 
+    @my_debug_logger()
     def subsample(self):
         """Method for subsampling cluster and metadata files"""
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -46,7 +46,7 @@ import re
 from pymongo import MongoClient
 from google.cloud import bigquery
 
-import google.cloud.logging
+# import google.cloud.logging
 from google.cloud.exceptions import NotFound
 from bson.objectid import ObjectId
 
@@ -575,7 +575,7 @@ def bq_dataset_exists(dataset):
         bigquery_client.get_dataset(dataset_ref)
         exists = True
     except NotFound:
-        self.errors_logger(f'Dataset {dataset} not found')
+        print(f'Dataset {dataset} not found')
     return exists
 
 
@@ -588,7 +588,7 @@ def bq_table_exists(dataset, table):
         bigquery_client.get_table(table_ref)
         exists = True
     except NotFound:
-        self.errors_logger(f'Dataset {table} not found')
+        print(f'Dataset {table} not found')
     return exists
 
 

--- a/ingest/monitor.py
+++ b/ingest/monitor.py
@@ -11,7 +11,6 @@ def setup_logger(logger_name, log_file, level=logging.DEBUG):
     handler.setFormatter(formatter)
     logger.setLevel(level)
     logger.addHandler(handler)
-
     return logger
 
 

--- a/ingest/subsample.py
+++ b/ingest/subsample.py
@@ -6,10 +6,12 @@ import numpy as np
 try:
     from annotations import Annotations
     from clusters import Clusters
+    from cell_metadata import CellMetadata
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .annotations import Annotations
     from .clusters import Clusters
+    from .cell_metadata import CellMetadata
 
 
 class SubSample(Annotations):
@@ -20,8 +22,8 @@ class SubSample(Annotations):
     def __init__(self, cluster_file, cell_metadata_file=None):
         Annotations.__init__(self, cluster_file, self.ALLOWED_FILE_TYPES)
         self.determine_coordinates_and_cell_names()
-        self.cell_metadata_df = (
-            Annotations(cell_metadata_file, self.ALLOWED_FILE_TYPES)
+        self.cell_metadata = (
+            Annotations(cell_metadata_file, CellMetadata.ALLOWED_FILE_TYPES)
             if cell_metadata_file is not None
             else None
         )
@@ -29,10 +31,10 @@ class SubSample(Annotations):
 
     def prepare_cell_metadata(self):
         """ Does an inner join on cell and cluster file """
-        if self.cell_metadata_df is not None:
-            self.cell_metadata_df.preproccess()
+        if self.cell_metadata is not None:
+            self.cell_metadata.preproccess()
             self.merge_df(
-                self.file[self.coordinates_and_cell_names], self.cell_metadata_df.file
+                self.file[self.coordinates_and_cell_names], self.cell_metadata.file
             )
             self.determine_coordinates_and_cell_names()
 

--- a/ingest/subsample.py
+++ b/ingest/subsample.py
@@ -22,11 +22,10 @@ class SubSample(Annotations):
     def __init__(self, cluster_file, cell_metadata_file=None):
         Annotations.__init__(self, cluster_file, self.ALLOWED_FILE_TYPES)
         self.determine_coordinates_and_cell_names()
-        self.cell_metadata = (
-            Annotations(cell_metadata_file, CellMetadata.ALLOWED_FILE_TYPES)
-            if cell_metadata_file is not None
-            else None
-        )
+        if cell_metadata_file is not None:
+            self.cell_metadata = Annotations(
+                cell_metadata_file, CellMetadata.ALLOWED_FILE_TYPES
+            )
         self.preproccess()
 
     def prepare_cell_metadata(self):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -29,7 +29,7 @@ from annotations import Annotations
 
 class TestAnnotations(unittest.TestCase):
     CLUSTER_PATH = '../tests/data/test_1k_cluster_data.csv'
-    CELL_METADATA_PATH = '../tests/data/subsample_metadata_test.csv'
+    CELL_METADATA_PATH = '../tests/data/valid_no_array_v1.1.3.tsv'
 
     EXPONENT = -3
 
@@ -67,7 +67,6 @@ class TestAnnotations(unittest.TestCase):
             ['text/csv', 'text/plain', 'text/tab-separated-values'],
         )
         cell_metadata_df.preproccess()
-
         cell_names_cell_metadata_df = np.asarray(cell_metadata_df.file['NAME'])
         cell_names_cluster_df = np.asarray(self.df.file['NAME'])
 

--- a/tests/test_ingest_files.py
+++ b/tests/test_ingest_files.py
@@ -26,5 +26,4 @@ class TestIngestFiles(unittest.TestCase):
             IngestFiles(
                 '/this/file/does/not_exist.txt',
                 ['text/csv', 'text/plain', 'text/tab-separated-values'],
-                open_as='dataframe',
             )


### PR DESCRIPTION
This PR allows R formatted gene expression files to be ingested. 

Also, support for txt files has been corrected. Prior, there was no way to determine if a .txt file was tab or comma delimited.  Because of this bug, when opening a .txt file, pandas could not format the dataframe properly.  This affected dense expression mtx, cluster, and cell metadata files.