### PR TITLE
expression matrix ingest bugfixes

### DIFF
--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -303,7 +303,6 @@ class IngestFiles:
             "csvDialect",
             delimiter=",",
             quotechar='"',
-            quoting=csv.QUOTE_NONNUMERIC,
             skipinitialspace=True,
             escapechar='\\',
         )
@@ -311,12 +310,7 @@ class IngestFiles:
 
     def open_tsv(self, opened_file_object, **kwargs):
         """Opens tsv file"""
-        csv.register_dialect(
-            "tsvDialect",
-            delimiter="\t",
-            quoting=csv.QUOTE_NONNUMERIC,
-            skipinitialspace=True,
-        )
+        csv.register_dialect("tsvDialect", delimiter="\t", skipinitialspace=True)
         return csv.reader(opened_file_object, dialect="tsvDialect")
 
     def extract_csv_or_tsv(self, file):

--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -309,7 +309,7 @@ class IngestFiles:
         )
         return csv.reader(opened_file_object, dialect="csvDialect")
 
-    def open_tsv(self, opened_file_object, file_type):
+    def open_tsv(self, opened_file_object, **kwargs):
         """Opens tsv file"""
         csv.register_dialect(
             "tsvDialect",

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -332,7 +332,7 @@ class IngestPipeline(object):
                     extra=self.extra_log_params,
                 )
                 return status
-        return 1
+        return status
 
     @my_debug_logger()
     def ingest_cell_metadata(self):


### PR DESCRIPTION
This small PR addresses two bugs found in testing expression matrix ingest:
1. successful parsing of dense expression matrix ended in exit status 1
2. ingest of tsv format dense expression matrices resulted in python errors

Notes: 
took expression_matrix_example_gzipped.txt.gz, uncompressed it, opened in Excel, saved as csv and tested csv ingest to confirm that it passes. For this simple csv file derived from a "known good" single_cell_portal_core test file, csvDialect (with csv.QUOTE_NONNUMERIC removed as for tsvDialect - to fix bug #2 above) seems ok. Unclear whether the escapechar parameter is needed for csvDialect - it is not present in tsvDialect.

also pulled ea-test-ingest-files 27641e5 into this branch and ran all tests (which passed) then reverted my branch to keep this small PR distinct from Eno's PR.