### PR TITLE
Support ingest for remote MTX bundle files (SCP-2042)

### DIFF
--- a/ingest/mtx.py
+++ b/ingest/mtx.py
@@ -17,24 +17,37 @@ import scipy.io
 
 try:
     from expression_files import GeneExpression
+    from ingest_files import IngestFiles
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .expression_files import GeneExpression
+    from .ingest_files import IngestFiles
 
 
 class Mtx(GeneExpression):
+    ALLOWED_FILE_TYPES = ["text/csv", "text/plain", "text/tab-separated-values"]
+
     def __init__(self, mtx_path: str, study_file_id: str, study_id: str, **kwargs):
         GeneExpression.__init__(self, mtx_path, study_file_id, study_id)
-        self.genes_file = open(kwargs.pop("gene_file"))
-        self.barcodes_file = open(kwargs.pop("barcode_file"))
-        self.mtx_path = mtx_path
+
+        genes_path = kwargs.pop("gene_file")
+        genes_ingest_file = IngestFiles(genes_path, self.ALLOWED_FILE_TYPES)
+        self.genes_file, genes_local_path = genes_ingest_file.resolve_path(genes_path)
+
+        barcodes_path = kwargs.pop("barcode_file")
+        barcodes_ingest_file = IngestFiles(barcodes_path, self.ALLOWED_FILE_TYPES)
+        self.barcodes_file, barcodes_local_path = barcodes_ingest_file.resolve_path(barcodes_path)
+
+        mtx_ingest_file = IngestFiles(mtx_path, self.ALLOWED_FILE_TYPES)
+        mtx_file, self.mtx_local_path = mtx_ingest_file.resolve_path(mtx_path)
+
         self.matrix_params = kwargs
         self.exp_by_gene = {}
 
     def extract(self):
         """Sets relevant iterables for each file of the MTX bundle
         """
-        self.matrix_file = scipy.io.mmread(self.mtx_path)
+        self.matrix_file = scipy.io.mmread(self.mtx_local_path)
         self.genes = [g.strip() for g in self.genes_file.readlines()]
         self.cells = [c.strip() for c in self.barcodes_file.readlines()]
 

--- a/ingest/mtx.py
+++ b/ingest/mtx.py
@@ -36,7 +36,9 @@ class Mtx(GeneExpression):
 
         barcodes_path = kwargs.pop("barcode_file")
         barcodes_ingest_file = IngestFiles(barcodes_path, self.ALLOWED_FILE_TYPES)
-        self.barcodes_file, barcodes_local_path = barcodes_ingest_file.resolve_path(barcodes_path)
+        self.barcodes_file, barcodes_local_path = barcodes_ingest_file.resolve_path(
+            barcodes_path
+        )
 
         mtx_ingest_file = IngestFiles(mtx_path, self.ALLOWED_FILE_TYPES)
         mtx_file, self.mtx_local_path = mtx_ingest_file.resolve_path(mtx_path)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -246,6 +246,44 @@ class IngestTestCase(unittest.TestCase):
         expected_model = get_gene_model(mock_dir)
         self.assertEqual(model, expected_model)
 
+    def test_remote_mtx_bundles(self):
+        """Ingest Pipeline should handle MTX matrix files fetched from bucket
+        """
+
+        args = [
+            '--study-id',
+            '5d276a50421aa9117c982845',
+            '--study-file-id',
+            '5dd5ae25421aa910a723a337',
+            'ingest_expression',
+            '--taxon-name',
+            'Homo sapiens',
+            '--taxon-common-name',
+            'human',
+            '--ncbi-taxid',
+            '9606',
+            '--genome-assembly-accession',
+            'GCA_000001405.15',
+            '--genome-annotation',
+            'Ensembl 94',
+            '--matrix-file',
+            'gs://fake-bucket/tests/data/matrix.mtx',
+            '--matrix-file-type',
+            'mtx',
+            '--gene-file',
+            'gs://fake-bucket/tests/data/genes.tsv',
+            '--barcode-file',
+            'gs://fake-bucket/tests/data/barcodes.tsv',
+        ]
+        ingest = self.setup_ingest(args)
+
+        model = ingest.load_args[1]
+        # print(model)
+
+        mock_dir = 'matrix_mtx'
+        expected_model = get_gene_model(mock_dir)
+        self.assertEqual(model, expected_model)
+
     def test_mtx_bundle_argument_validation(self):
         """Omitting --gene-file and --barcode-file in MTX ingest should error
         """


### PR DESCRIPTION
This fixes a bug in handling remote gene files and barcode files in an MTX bundle.

In addition to a new automated test, I've also verified the fix using files in our test data bucket.

This satisfies SCP-2042.