### PR TITLE
restore error report on detection of invalid cell metadata file format

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -374,6 +374,7 @@ class IngestPipeline(object):
                     return status
             return status if status is not None else 1
         else:
+            report_issues(self.cell_metadata)
             self.errors_logger.error(
                 f'Cell metadata file format invalid', extra=self.extra_log_params
             )


### PR DESCRIPTION
Invalidly formatted cell metadata files receive terse message without remediation details:
__main___errors - ERROR - Cell metadata file format invalid

This small change restores the reporting of collected cell metadata file format errors so end users know what format issues need to be addressed.