### PR TITLE
Upgrade Docker to use Python 3.7 (SCP-2056)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,11 @@ FROM marketplace.gcr.io/google/ubuntu1804:latest
 
 #RUN echo "Uncomment to clear cached layers below this statement (20190708-1259)"
 
-# Install Python 3.6
-# (Auxiliary Ubuntu packages for Python assume Python 3.6;
-# configuring them for Python >= 3.7 is not straightforward.)
+# Install Python 3.7
 RUN apt-get -y update && \
   apt -y install software-properties-common dirmngr apt-transport-https lsb-release ca-certificates && \
   add-apt-repository ppa:deadsnakes/ppa && \
-  apt -y install python3.6 && \
+  apt -y install python3.7 && \
   apt -y install python3-pip
 
 # Set cleaner defaults (`alias` fails)

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ WORKDIR /scp-ingest-pipeline
 RUN pip install -r requirements.txt
 
 WORKDIR /scp-ingest-pipeline/ingest
-CMD ["python", "ingest_pipeline.py", "--help"]
+#CMD ["python", "ingest_pipeline.py", "--help"]
+CMD ["python", "--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ WORKDIR /scp-ingest-pipeline
 RUN pip install -r requirements.txt
 
 WORKDIR /scp-ingest-pipeline/ingest
-CMD ["python", "ingest.py", "--help"]
+CMD ["python", "ingest_pipeline.py", "--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,19 @@
 # https://github.com/GoogleContainerTools/base-images-docker/tree/master/ubuntu
 FROM marketplace.gcr.io/google/ubuntu1804:latest
 
-#RUN echo "Uncomment to clear cached layers below this statement (20190708-1259)"
+# RUN echo "Uncomment to clear cached layers below this statement (2020-01-07-0947)"
 
 # Install Python 3.7
 RUN apt-get -y update && \
-  apt -y install software-properties-common dirmngr apt-transport-https lsb-release ca-certificates && \
+  apt -y install software-properties-common && \
   add-apt-repository ppa:deadsnakes/ppa && \
-  apt -y install python3.7 && \
-  apt -y install python3-pip
+  apt -y install python3-pip && \
+  apt -y install python3.7
+
+RUN python3.7 -m pip install pip
 
 # Set cleaner defaults (`alias` fails)
-RUN ln -s /usr/bin/python3 /usr/bin/python && \
+RUN ln -s /usr/bin/python3.7 /usr/bin/python && \
   ln -s /usr/bin/pip3 /usr/bin/pip
 
 # Copy contents of this repo into the Docker image
@@ -35,5 +37,4 @@ WORKDIR /scp-ingest-pipeline
 RUN pip install -r requirements.txt
 
 WORKDIR /scp-ingest-pipeline/ingest
-#CMD ["python", "ingest_pipeline.py", "--help"]
-CMD ["python", "--help"]
+CMD ["python", "ingest_pipeline.py", "--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . scp-ingest-pipeline
 WORKDIR /scp-ingest-pipeline
 
 # Install Python dependencies
-RUN pip install -r requirements.txt
+RUN python3.7 -m pip install -r requirements.txt
 
 WORKDIR /scp-ingest-pipeline/ingest
 CMD ["python", "ingest_pipeline.py", "--help"]

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -31,7 +31,7 @@ python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5
 python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_subsample --cluster-file ../tests/data/test_1k_cluster_Data.csv --name custer1 --cell-metadata-file ../tests/data/test_1k_metadata_Data.csv --subsample
 
 # Ingest mtx files
-python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_expression --taxon-name 'Homo Sapiens' --taxon-common-name humans --matrix-file ../tests/data/matrix.mtx --matrix-file-type mtx --gene-file ../tests/data/genes.tsv --barcode-file ../tests/data/barcodes.tsv
+python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_expression --taxon-name 'Homo sapiens' --taxon-common-name humans --matrix-file ../tests/data/matrix.mtx --matrix-file-type mtx --gene-file ../tests/data/genes.tsv --barcode-file ../tests/data/barcodes.tsv
 """
 import argparse
 from typing import Dict, Generator, List, Tuple, Union  # noqa: F401


### PR DESCRIPTION
This upgrades the Docker image used on PAPI to use Python 3.7.  That is needed because our new Stackdriver Monitor code (#68) [uses `nullcontext`](https://github.com/broadinstitute/scp-ingest-pipeline/pull/68/files#diff-4799e037644be7d4de8355150394dbe6R140), which is [new in 3.7](https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext).

I've built a new Docker image with the updated `Dockerfile`, and verified that `docker run` now succeeds for it.

This satisfies SCP-2056.