### PR TITLE
Exponential backoff & error handling for metadata validation

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -19,7 +19,7 @@ python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5d
 
 # Ingest Cell Metadata file against convention
 !! Please note that you must have a pre-configured BigQuery table available
-python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_cell_metadata --cell-metadata-file ../tests/data/valid_no_array_v1.1.3.tsv --ingest-cell-metadata --validate-convention --bq-dataset cell_metadata --bq-table alexandria_convention
+python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_cell_metadata --cell-metadata-file ../tests/data/valid_no_array_v1.1.3.tsv --study-accession SCP123 --ingest-cell-metadata --validate-convention --bq-dataset cell_metadata --bq-table alexandria_convention
 
 # Ingest dense file
 python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_expression --taxon-name 'Homo sapiens' --taxon-common-name human --ncbi-taxid 9606 --matrix-file ../tests/data/dense_matrix_19_genes_100k_cells.txt --matrix-file-type dense

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -500,11 +500,11 @@ def exit_if_errors(metadata):
 
 def backoff_handler(details):
     """Handler function to log backoff attempts when querying OLS"""
-    logger.debug("Backing off {wait:0.1f} seconds afters {tries} tries "
+    logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
            "calling function {target} with args {args} and kwargs "
            "{kwargs}".format(**details))
 
-# Decorator to attach exponential backoff to external HTTP requests
+# Attach exponential backoff to external HTTP requests
 @backoff.on_exception(backoff.expo,
                       requests.exceptions.RequestException,
                       max_time=MAX_HTTP_REQUEST_TIME,
@@ -524,7 +524,7 @@ def retrieve_ontology(ontology_url):
     else:
         return None
 
-# Decorator to attach exponential backoff to external HTTP requests
+# Attach exponential backoff to external HTTP requests
 @backoff.on_exception(backoff.expo,
                       requests.exceptions.RequestException,
                       max_time=MAX_HTTP_REQUEST_TIME,

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -8,7 +8,8 @@ participating under the convention.
 
 EXAMPLE
 # Using JSON file for Alexandria metadata convention TSV, validate input TSV
-$ python3 validate_metadata.py ../../tests/data/AMC_v0.8.json ../../tests/data/metadata_valid.tsv
+$ python3 validate_metadata.py ../../tests/data/AMC_v1.1.3.json ../../tests/data/valid_no_array_v1.1.3.tsv \
+          --study-accession SCP123 --study-id 5dfa6718421aa90fea085476 --study-file-id 5e27451e2209c211b1e7c9cc
 
 """
 
@@ -23,6 +24,7 @@ import re
 import os
 import numbers
 import time
+import backoff
 
 import colorama
 from colorama import Fore
@@ -46,6 +48,9 @@ logger = logging.getLogger(__name__)
 # Ensures normal color for print() output, unless explicitly changed
 colorama.init(autoreset=True)
 
+# Configure maximum number of seconds to spend & total attempts at external HTTP requests to services, e.g. OLS
+MAX_HTTP_REQUEST_TIME = 120
+MAX_HTTP_ATTEMPTS = 8
 
 def create_parser():
     """Parse command line values for validate_metadata
@@ -493,27 +498,44 @@ def exit_if_errors(metadata):
         exit(1)
     return errors
 
+def backoff_hdlr(details):
+    """Handler function to log backoff attempts when querying OLS"""
+    logger.debug("Backing off {wait:0.1f} seconds afters {tries} tries "
+           "calling function {target} with args {args} and kwargs "
+           "{kwargs}".format(**details))
 
+# Decorator to attach exponential backoff to external HTTP requests
+@backoff.on_exception(backoff.expo,
+                      requests.exceptions.RequestException,
+                      max_time=MAX_HTTP_REQUEST_TIME,
+                      max_tries=MAX_HTTP_ATTEMPTS,
+                      on_backoff=backoff_hdlr,
+                      logger="logger")
 def retrieve_ontology(ontology_url):
     """Retrieve an ontology listing from EBI OLS
     returns JSON payload of ontology, or None if unsuccessful
     """
     # add timeout to prevent request from hanging indefinitely
     response = requests.get(ontology_url, timeout=60)
-    # inserting sleep to avoid 'Connection timed out' error with too many concurrent requests
+    # inserting sleep to minimize 'Connection timed out' error with too many concurrent requests
     time.sleep(0.25)
     if response.status_code == 200:
         return response.json()
     else:
         return None
 
-
+# Decorator to attach exponential backoff to external HTTP requests
+@backoff.on_exception(backoff.expo,
+                      requests.exceptions.RequestException,
+                      max_time=MAX_HTTP_REQUEST_TIME,
+                      max_tries=MAX_HTTP_ATTEMPTS,
+                      on_backoff=backoff_hdlr,
+                      logger="logger")
 def retrieve_ontology_term(convention_url, ontology_id):
     """Retrieve an individual term from an ontology
     returns JSON payload of ontology, or None if unsuccessful
     """
     OLS_BASE_URL = 'https://www.ebi.ac.uk/ols/api/ontologies/'
-    convention_ontology = retrieve_ontology(convention_url)
     # separate ontology shortname from term ID number
     # valid separators are underscore and colon (used by HCA)
     try:
@@ -524,13 +546,23 @@ def retrieve_ontology_term(convention_url, ontology_id):
         return None
     metadata_url = OLS_BASE_URL + ontology_shortname
     metadata_ontology = retrieve_ontology(metadata_url)
+    # check if the ontology parsed from the term is the same ontology defined in the convention
+    # if so, skip the extra call to OLS; otherwise, retrieve the convention-defined ontology for term lookups
+    if metadata_ontology is not None:
+        reference_url = metadata_ontology['_links']['self']['href']
+        if reference_url.lower() == convention_url.lower():
+            convention_ontology = metadata_ontology.copy()
+        else:
+            convention_ontology = retrieve_ontology(convention_url)
+    else:
+        convention_ontology = None # we did not get a metadata_ontology, so abort the check
     if convention_ontology and metadata_ontology:
         base_term_uri = metadata_ontology['config']['baseUris'][0]
         query_iri = encode_term_iri(term_id, base_term_uri)
         term_url = convention_ontology['_links']['terms']['href'] + '/' + query_iri
         # add timeout to prevent request from hanging indefinitely
         response = requests.get(term_url, timeout=60)
-        # inserting sleep to avoid 'Connection timed out' error with too many concurrent requests
+        # inserting sleep to minimize 'Connection timed out' error with too many concurrent requests
         time.sleep(0.25)
         if response.status_code == 200:
             return response.json()
@@ -627,6 +659,16 @@ def validate_collected_ontology_data(metadata, convention):
                     f'\"{ontology_id}\" - no cross-check for data entry error possible'
                 )
                 metadata.store_validation_issue('warn', 'ontology', error_msg)
+        except requests.exceptions.RequestException as err:
+            error_msg = f'External service outage connecting to {ontology_url} when querying {ontology_id}:{ontology_label}: {err}'
+            logger.error(error_msg)
+            metadata.store_validation_issue(
+                'error',
+                'ontology',
+                error_msg
+            )
+            # immediately return as validation cannot continue
+            return
     return
 
 

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -498,7 +498,7 @@ def exit_if_errors(metadata):
         exit(1)
     return errors
 
-def backoff_hdlr(details):
+def backoff_handler(details):
     """Handler function to log backoff attempts when querying OLS"""
     logger.debug("Backing off {wait:0.1f} seconds afters {tries} tries "
            "calling function {target} with args {args} and kwargs "
@@ -509,7 +509,7 @@ def backoff_hdlr(details):
                       requests.exceptions.RequestException,
                       max_time=MAX_HTTP_REQUEST_TIME,
                       max_tries=MAX_HTTP_ATTEMPTS,
-                      on_backoff=backoff_hdlr,
+                      on_backoff=backoff_handler,
                       logger="logger")
 def retrieve_ontology(ontology_url):
     """Retrieve an ontology listing from EBI OLS
@@ -529,7 +529,7 @@ def retrieve_ontology(ontology_url):
                       requests.exceptions.RequestException,
                       max_time=MAX_HTTP_REQUEST_TIME,
                       max_tries=MAX_HTTP_ATTEMPTS,
-                      on_backoff=backoff_hdlr,
+                      on_backoff=backoff_handler,
                       logger="logger")
 def retrieve_ontology_term(convention_url, ontology_id, ontologies):
     """Retrieve an individual term from an ontology
@@ -546,7 +546,7 @@ def retrieve_ontology_term(convention_url, ontology_id, ontologies):
     except (ValueError, TypeError):
         return None
     # check if we have already retrieved this ontology reference
-    if ontology_shortname not in ontologies.keys():
+    if ontology_shortname not in ontologies:
         metadata_url = OLS_BASE_URL + ontology_shortname
         ontologies[ontology_shortname] = retrieve_ontology(metadata_url)
     metadata_ontology = ontologies[ontology_shortname]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ dataclasses==0.6
 loompy==2.0.15
 colorama==0.4.1
 pymongo==3.9.0
+backoff==1.10.0
 
 # Dev dependencies
 pytest==5.0.1

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -19,6 +19,8 @@ import unittest
 import json
 import os
 from bson.objectid import ObjectId
+import requests
+from unittest.mock import patch
 
 sys.path.append('../ingest')
 sys.path.append('../ingest/validation')
@@ -31,8 +33,13 @@ from validate_metadata import (
     CellMetadata,
     validate_collected_ontology_data,
     validate_input_metadata,
+    retrieve_ontology,
+    MAX_HTTP_ATTEMPTS
 )
 
+# do not attempt a request, but instead throw a request exception
+def mocked_requests_get(*args, **kwargs):
+    raise requests.exceptions.RequestException
 
 class TestValidateMetadata(unittest.TestCase):
     def setup_metadata(self, args):
@@ -255,6 +262,13 @@ class TestValidateMetadata(unittest.TestCase):
         )
         self.teardown_metadata(metadata)
 
+    @patch('requests.get', side_effect=mocked_requests_get)
+    def test_request_backoff_handling(self, mocked_requests_get):
+        """errors in retrieving data from external resources should attempt MAX_HTTP_ATTEMPTS times and throw an exception
+        """
+        request_url = 'https://www.ebi.ac.uk/ols/api/ontologies/'
+        self.assertRaises(requests.exceptions.RequestException, retrieve_ontology, request_url)
+        self.assertEqual(mocked_requests_get.call_count, MAX_HTTP_ATTEMPTS)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adding exponential backoff with "[full jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)" to all external calls to OLS when validating convention metadata.  Caching of retrieved ontologies has also been added to reduce the number of external API calls and speed up validation.  If all retries fail to connect (and validation is therefore impossible at the current time) then an error is reported back to ingest with a special error message denoting that an 'External service outage' has occurred.  This message will then be included in an email back to the user from the portal.

This PR satisfies [SCP-2076](https://broadworkbench.atlassian.net/browse/SCP-2076).