### PR TITLE
Disable memory_profiler to fix Docker build (SCP-2053)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ opencensus-context==0.1.1
 opencensus-ext-stackdriver==0.7.2
 google-cloud-trace==0.23.0
 
-memory-profiler==0.57.0
+# memory-profiler==0.57.0


### PR DESCRIPTION
This comments out memory_profiler due to failed Docker build with `psutil`.  To profile memory, simply uncomment the `memory_profiler` line in `requirements.txt`, then follow instructions from #74.

Information below is simply for reference.

Failing Cloud Build, which I reproduced locally:
https://console.cloud.google.com/cloud-build/builds/42daf386-5aff-45d1-96b3-0706ea769de0?project=broad-singlecellportal-staging

Error:
```
copying psutil/tests/test_misc.py -> build/lib.linux-x86_64-3.7/psutil/tests
running build_ext
building 'psutil._psutil_linux' extension
creating build/temp.linux-x86_64-3.7
creating build/temp.linux-x86_64-3.7/psutil
x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fdebug-prefix-map=/build/python3.7-WA8NgD/python3.7-3.7.6=. -fstack-protector-strong -Wformat -Werror=format-security -g -fdebug-prefix-map=/build/python3.7-WA8NgD/python3.7-3.7.6=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_VERSION=567 -DPSUTIL_LINUX=1 -I/usr/include/python3.7m -c psutil/_psutil_common.c -o build/temp.linux-x86_64-3.7/psutil/_psutil_common.o
psutil/_psutil_common.c:9:10: fatal error: Python.h: No such file or directory
#include <Python.h>
^~~~~~~~~~
compilation terminated.
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

----------------------------------------
Command "/usr/bin/python3.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-u87trqka/psutil/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-glh9e23s-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-u87trqka/psutil/
The command '/bin/sh -c python3.7 -m pip install -r requirements.txt' returned a non-zero code: 1
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 1
```

I verified the fix locally by doing a successful Docker build with this commented-out requirement.  I'll note refining this setup process as a stretch goal in the follow-up ticket for infrastructure for profiling memory, SCP-2081.

This fixes a bug in SCP-2053.