### PR TITLE
capture metadata convention validation errors via logger (SCP-2092)

### DIFF
--- a/ingest/monitor.py
+++ b/ingest/monitor.py
@@ -4,15 +4,19 @@ import time
 from contextlib import nullcontext
 
 
-def setup_logger(logger_name, log_file, level=logging.DEBUG):
+def setup_logger(logger_name, log_file, level=logging.DEBUG, format='default'):
     logger = logging.getLogger(logger_name)
-    formatter = logging.Formatter(
-        '[%(asctime)s] %(levelname)s [%(study_id)s.%(name)s.%(funcName)s:%(lineno)d:%(duration)s] %(message)s'
-    )
+    if format == 'default':
+        formatter = logging.Formatter(
+            '[%(asctime)s] %(levelname)s [%(study_id)s.%(name)s.%(funcName)s:%(lineno)d:%(duration)s] %(message)s'
+        )
+    else:
+        formatter = logging.Formatter(format)
     handler = logging.FileHandler(log_file)
     handler.setFormatter(formatter)
     logger.setLevel(level)
     logger.addHandler(handler)
+    logger.propagate = False
     return logger
 
 

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -398,9 +398,10 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
     # the latter two should be done together in the same pass thru the file
     js_errors = defaultdict(list)
     schema = validate_schema(convention, metadata)
-    # truncate jsonfile so appends invoked below are added to an empty file
+
     if bq_json:
         bq_filename = str(metadata.study_file_id) + '.json'
+        # truncate jsonfile so data from serialize_bq starts with an empty file
         fh = open(bq_filename, 'w')
         fh.close()
     if schema:

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -426,14 +426,13 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
         return False
 
 
-def record_issue(errfile, warnfile, issue_type, msg, error_logger):
+def record_issue(errfile, warnfile, issue_type, msg):
     """print issue to console with coloring and
     writes issues to appropriate issue file
     """
 
     if issue_type == 'error':
         errfile.write(msg + '\n')
-        # error_logger.error(msg, extra={'study_id': None, 'duration': None})
         error_logger.error(msg)
         color = Fore.RED
     elif issue_type == 'warn':
@@ -463,7 +462,7 @@ def report_issues(metadata):
         for issue_category, category_dict in metadata.issues[issue_type].items():
             if category_dict:
                 category_header = f'\n*** {issue_category} {issue_type} list:'
-                record_issue(error_file, warn_file, issue_type, category_header, error_logger)
+                record_issue(error_file, warn_file, issue_type, category_header)
                 if issue_type == 'error':
                     has_errors = True
                 elif issue_type == 'warn':
@@ -471,12 +470,12 @@ def report_issues(metadata):
                 for issue_text, cells in category_dict.items():
                     if cells:
                         issue_msg = f'{issue_text} [ Error count: {len(cells)} ]'
-                        record_issue(error_file, warn_file, issue_type, issue_msg, error_logger)
+                        record_issue(error_file, warn_file, issue_type, issue_msg)
                     else:
-                        record_issue(error_file, warn_file, issue_type, issue_text, error_logger)
+                        record_issue(error_file, warn_file, issue_type, issue_text)
     if not has_errors and not has_warnings:
         no_issues = 'No errors or warnings detected for input metadata file'
-        record_issue(error_file, warn_file, None, no_issues, error_logger)
+        record_issue(error_file, warn_file, None, no_issues)
     error_file.close()
     warn_file.close()
     return has_errors

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -785,11 +785,9 @@ def push_metadata_to_bq(metadata, ndjson, dataset, table):
         info_logger.info(e, extra={'study_id': metadata.study_id, 'duration': None})
         return 1
     if job.output_rows != len(metadata.cells):
-        info_msg = f'BigQuery upload error: upload ({job.output_rows} rows) does not match number of cells in file, {len(metadata.cells)} cells'
-        print(info_msg)
-        info_logger.info(
-            info_msg, extra={'study_id': metadata.study_id, 'duration': None}
-        )
+        error_msg = f'BigQuery upload error: upload ({job.output_rows} rows) does not match number of cells in file, {len(metadata.cells)} cells'
+        print(error_msg)
+        error_logger.error(error_msg)
         return 1
     os.remove(ndjson)
     return 0

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -398,6 +398,11 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
     # the latter two should be done together in the same pass thru the file
     js_errors = defaultdict(list)
     schema = validate_schema(convention, metadata)
+    # truncate jsonfile so appends invoked below are added to an empty file
+    if bq_json:
+        bq_filename = str(metadata.study_file_id) + '.json'
+        with open(bq_filename, 'w') as jsonfile:
+            pass
     if schema:
         compare_type_annots_to_convention(metadata, convention)
         rows = metadata.yield_by_row()
@@ -413,7 +418,6 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
                     pass
                 js_errors[error.message].append(row['CellID'])
             if bq_json:
-                bq_filename = str(metadata.study_file_id) + '.json'
                 # add non-convention, SCP-required, metadata for BigQuery
                 row['study_accession'] = metadata.study_accession
                 row['file_id'] = str(metadata.study_file_id)

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -401,7 +401,7 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
 
     if bq_json:
         bq_filename = str(metadata.study_file_id) + '.json'
-        # truncate jsonfile so data from serialize_bq starts with an empty file
+        # truncate JSON file so data from serialize_bq starts with an empty file
         fh = open(bq_filename, 'w')
         fh.close()
     if schema:

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -401,8 +401,8 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
     # truncate jsonfile so appends invoked below are added to an empty file
     if bq_json:
         bq_filename = str(metadata.study_file_id) + '.json'
-        with open(bq_filename, 'w') as jsonfile:
-            pass
+        fh = open(bq_filename, 'w')
+        fh.close()
     if schema:
         compare_type_annots_to_convention(metadata, convention)
         rows = metadata.yield_by_row()


### PR DESCRIPTION
This modifies validation against metadata convention to use the logging functionality from monitor.py so metadata convention validation errors will be included in the errors.txt file allowing validation information to be passed to the end user in the parsing notification email.

Additionally, detection of discrepancy between the number of cells prepared for upload from the input metadata file and the number of rows inserted in the BigQuery job will now be reported in errors.txt.

This issue fulfills [SCP-2092](https://broadworkbench.atlassian.net/browse/SCP-2092).