### PR TITLE
Regularize stored ontology IDs (SCP-2116)

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -229,7 +229,7 @@ class IngestPipeline(object):
             self.error_logger.error(e, extra=self.extra_log_params)
             try:
                 self.error_logger.error(e.details, extra=self.extra_log_params)
-            except AttributeError as e:
+            except AttributeError:
                 self.error_logger.error(
                     'Check access to MongoDB', extra=self.extra_log_params
                 )

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -227,13 +227,12 @@ class IngestPipeline(object):
                 self.insert_many('data_arrays', documents)
         except Exception as e:
             self.error_logger.error(e, extra=self.extra_log_params)
-            self.error_logger.error(
-                'Unable to access to MongoDB?', extra=self.extra_log_params
-            )
             try:
                 self.error_logger.error(e.details, extra=self.extra_log_params)
             except AttributeError as e:
-                self.error_logger.error(e, extra=self.extra_log_params)
+                self.error_logger.error(
+                'Check access to MongoDB', extra=self.extra_log_params
+            )
             return 1
         return 0
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -231,8 +231,8 @@ class IngestPipeline(object):
                 self.error_logger.error(e.details, extra=self.extra_log_params)
             except AttributeError as e:
                 self.error_logger.error(
-                'Check access to MongoDB', extra=self.extra_log_params
-            )
+                    'Check access to MongoDB', extra=self.extra_log_params
+                )
             return 1
         return 0
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -227,8 +227,11 @@ class IngestPipeline(object):
                 self.insert_many('data_arrays', documents)
         except Exception as e:
             self.error_logger.error(e, extra=self.extra_log_params)
-            if e.details is not None:
+            self.error_logger.error('Unable to access to MongoDB?', extra=self.extra_log_params)
+            try:
                 self.error_logger.error(e.details, extra=self.extra_log_params)
+            except AttributeError as e:
+                self.error_logger.error(e, extra=self.extra_log_params)
             return 1
         return 0
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -227,7 +227,9 @@ class IngestPipeline(object):
                 self.insert_many('data_arrays', documents)
         except Exception as e:
             self.error_logger.error(e, extra=self.extra_log_params)
-            self.error_logger.error('Unable to access to MongoDB?', extra=self.extra_log_params)
+            self.error_logger.error(
+                'Unable to access to MongoDB?', extra=self.extra_log_params
+            )
             try:
                 self.error_logger.error(e.details, extra=self.extra_log_params)
             except AttributeError as e:

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -227,11 +227,12 @@ class IngestPipeline(object):
                 self.insert_many('data_arrays', documents)
         except Exception as e:
             self.error_logger.error(e, extra=self.extra_log_params)
-            try:
+            if hasattr(e, 'details') and e.details is not None:
                 self.error_logger.error(e.details, extra=self.extra_log_params)
-            except AttributeError:
+            else:
                 self.error_logger.error(
-                    'Check access to MongoDB', extra=self.extra_log_params
+                    'Error loading data to MongoDB (no details available) - check MongoDB access',
+                    extra=self.extra_log_params,
                 )
             return 1
         return 0

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -336,12 +336,10 @@ def regularize_ontology_id(value):
     """Regularize ontology_ids for storage with underscore format
     """
     try:
-        ontology_shortname, term_id = re.split('[_:]', value)
-        value = ontology_shortname + '_' + term_id
-        return value
-    # when ontology_id is malformed and has no separator -> ValueError
-    # when ontology_id value is empty string -> TypeError
-    except (ValueError, TypeError):
+        return value.replace(":", "_")
+    except AttributeError:
+        # when expected value is not actually an ontology ID
+        # return the bad value for JSON schema validation
         return value
 
 

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -307,7 +307,7 @@ def cast_integer_type(value):
     """Cast metadata value as integer
     """
     if value_is_nan(value):
-    # nan indicates missing data, has no valid integer value for casting
+        # nan indicates missing data, has no valid integer value for casting
         return value
     else:
         return int(value)
@@ -323,8 +323,8 @@ def cast_string_type(value):
     """Cast string type per convention where Pandas autodetected a number
     """
     if value_is_nan(value):
-    # nan indicates missing data; by type, nan is a numpy float
-    # so a separate type check is needed for proper handling
+        # nan indicates missing data; by type, nan is a numpy float
+        # so a separate type check is needed for proper handling
         return value
     elif isinstance(value, numbers.Number):
         return str(value)

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -292,7 +292,11 @@ def cast_boolean_type(value):
     else:
         raise ValueError(f'cannot cast {value} as boolean')
 
+
 def value_is_nan(value):
+    """Check if value is nan
+    nan is a special dataframe value to indicate missing data
+    """
     try:
         return np.isnan(value)
     except TypeError:
@@ -303,6 +307,7 @@ def cast_integer_type(value):
     """Cast metadata value as integer
     """
     if value_is_nan(value):
+    # nan indicates missing data, has no valid integer value for casting
         return value
     else:
         return int(value)
@@ -318,11 +323,14 @@ def cast_string_type(value):
     """Cast string type per convention where Pandas autodetected a number
     """
     if value_is_nan(value):
+    # nan indicates missing data; by type, nan is a numpy float
+    # so a separate type check is needed for proper handling
         return value
     elif isinstance(value, numbers.Number):
         return str(value)
     else:
         return value
+
 
 def regularize_ontologyID(value):
     """Regularize ontologyIDs for storage with underscore format
@@ -335,6 +343,7 @@ def regularize_ontologyID(value):
     # when ontologyID value is empty string -> TypeError
     except (ValueError, TypeError):
         return value
+
 
 def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metadata):
     """for metadatum, lookup expected type by metadata convention
@@ -359,7 +368,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
                     if 'ontology' in convention['properties'][metadatum]:
                         element = regularize_ontologyID(element)
                 except KeyError:
-                # non-metadata convention metadata will trigger this exception
+                    # non-metadata convention metadata will trigger this exception
                     pass
                 cast_element = metadata_types.get(
                     lookup_metadata_type(convention, metadatum)
@@ -383,17 +392,17 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
                     value = regularize_ontologyID(value)
             except KeyError:
                 # non-metadata convention metadata will trigger this exception
-                    pass
-            cast_metadata[metadatum] = [metadata_types.get(
-                lookup_metadata_type(convention, metadatum)
-            )(value)]
+                pass
+            cast_metadata[metadatum] = [
+                metadata_types.get(lookup_metadata_type(convention, metadatum))(value)
+            ]
     else:
         try:
             if 'ontology' in convention['properties'][metadatum]:
                 value = regularize_ontologyID(value)
         except KeyError:
             # non-metadata convention metadata will trigger this exception
-                pass
+            pass
         try:
             cast_value = metadata_types.get(
                 lookup_metadata_type(convention, metadatum)

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -332,15 +332,15 @@ def cast_string_type(value):
         return value
 
 
-def regularize_ontologyID(value):
-    """Regularize ontologyIDs for storage with underscore format
+def regularize_ontology_id(value):
+    """Regularize ontology_ids for storage with underscore format
     """
     try:
         ontology_shortname, term_id = re.split('[_:]', value)
         value = ontology_shortname + '_' + term_id
         return value
-    # when ontolgyID is malformed and has no separator -> ValueError
-    # when ontologyID value is empty string -> TypeError
+    # when ontology_id is malformed and has no separator -> ValueError
+    # when ontology_id value is empty string -> TypeError
     except (ValueError, TypeError):
         return value
 
@@ -366,9 +366,9 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
             for element in value.split('|'):
                 try:
                     if 'ontology' in convention['properties'][metadatum]:
-                        element = regularize_ontologyID(element)
+                        element = regularize_ontology_id(element)
                 except KeyError:
-                    # non-metadata convention metadata will trigger this exception
+                    # unconventional metadata will trigger this exception
                     pass
                 cast_element = metadata_types.get(
                     lookup_metadata_type(convention, metadatum)
@@ -389,9 +389,9 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
         except AttributeError:
             try:
                 if 'ontology' in convention['properties'][metadatum]:
-                    value = regularize_ontologyID(value)
+                    value = regularize_ontology_id(value)
             except KeyError:
-                # non-metadata convention metadata will trigger this exception
+                # unconventional metadata will trigger this exception
                 pass
             cast_metadata[metadatum] = [
                 metadata_types.get(lookup_metadata_type(convention, metadatum))(value)
@@ -399,9 +399,9 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
     else:
         try:
             if 'ontology' in convention['properties'][metadatum]:
-                value = regularize_ontologyID(value)
+                value = regularize_ontology_id(value)
         except KeyError:
-            # non-metadata convention metadata will trigger this exception
+            # unconventional metadata will trigger this exception
             pass
         try:
             cast_value = metadata_types.get(
@@ -607,9 +607,9 @@ def retrieve_ontology_term(convention_url, ontology_id, ontologies):
     # valid separators are underscore and colon (used by HCA)
     try:
         ontology_shortname, term_id = re.split('[_:]', ontology_id)
-    # when ontolgyID is malformed and has no separator -> ValueError
-    # when ontologyID value is empty string -> TypeError
     except (ValueError, TypeError):
+        # when ontology_id is malformed and has no separator -> ValueError
+        # when ontology_id value is empty string -> TypeError
         return None
     # check if we have already retrieved this ontology reference
     if ontology_shortname not in ontologies:

--- a/tests/data/issues_metadata_v1.1.3.json
+++ b/tests/data/issues_metadata_v1.1.3.json
@@ -20,7 +20,10 @@
         "BM01_16dpp_CGGTAAACCATT",
         "BM01_16dpp_AAGCAGTGGTAT"
       ],
-      "is_living: 'nan' is not one of ['yes', 'no', 'unknown']": [
+      "is_living: nan is not one of ['yes', 'no', 'unknown']": [
+        "BM01_16dpp_TAAGCAGTGGTA"
+      ],
+      "is_living: nan is not of type 'string'": [
         "BM01_16dpp_TAAGCAGTGGTA"
       ],
       "sample_type: 'direct from donr - fresh' is not one of ['cell line', 'organoid', 'direct from donor - fresh', 'direct from donor - frozen', 'cultured primary cells']": [

--- a/tests/data/issues_ontology_v1.1.3.json
+++ b/tests/data/issues_ontology_v1.1.3.json
@@ -1,10 +1,13 @@
 {
   "error": {
     "convention": {
-      "cell_type: 'nan' does not match '^[A-Za-z]+[_:][0-9]'": [
+      "cell_type: nan is not of type 'string'": [
         "BM01_16dpp_AAGCAGTGGTAT"
       ],
-      "geographical_region: 'nan' does not match '^[A-Za-z]+[_:][0-9]'": [
+      "geographical_region: nan is not of type 'string'": [
+        "BM01_16dpp_AAGCAGTGGTAT"
+      ],
+      "geographical_region__ontology_label: nan is not of type 'string'": [
         "BM01_16dpp_AAGCAGTGGTAT"
       ],
       "library_preparation_protocol: 'EFO0008919' does not match '^[A-Za-z]+[_:][0-9]'": [


### PR DESCRIPTION
Refactored data preparation for BigQuery upload to consistently store ontology IDs using the underscore format to simplify metadata query on ontology IDs.

Additional changes include:
- additional error messaging where ingest pipeline load fails due to lack of MongoDB access
- fix lurking issue where single value arrays were not being cast to convention-specified data type
- fix lurking issue where cast_integer_type would fail if value was nan
- avoid casting nan to string because nan is indicative of missing values
- update reference json for metadata validation tests due to changes in nan handling

NOTE: current JSON Schema validation implementation REQUIRES that non-float convention metadata cannot have nan values. SCP-2137 has been created to address this unintended requirement which becomes blocking for metadata files from cell-based advanced search results.

This PR satisfies [SCP-2116](https://broadworkbench.atlassian.net/browse/SCP-2116)