### PR TITLE
Put BigQuery schema under source control (SCP-2289)

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -2,12 +2,16 @@
 
 * &lt;project&gt;_convention_schema.tsv - human-readable file used to generate the JSON document
 * &lt;project&gt;_convention_schema.json - used by ingest pipeline for metadata validation
+* scp_bq_inputs.json - file indicating non-metadata convention terms added to BigQuery for SCP use
+* &lt;project&gt;_convention_schema.bq_schema.json - representation of BigQuery schema
 
 # To update an existing metadata convention
 
 * Create a new snapshot directory under schema/&lt;project&gt;_convention/snapshot using semantic versioning conventions  
 
 * Make desired metadata convention updates to a copy of &lt;project&gt;_convention_schema.tsv file in the snapshot directory  
+
+* copy scp_bq_inputs.json from previous snapshot directory, update with new SCP-internal terms if appropriate
 
 * In the scripts `scp-ingest-pipeline` directory, run
   ```

--- a/schema/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.bq_schema.json
+++ b/schema/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.bq_schema.json
@@ -1,0 +1,452 @@
+[
+    {
+        "mode": "NULLABLE",
+        "name": "biosample_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "biosample_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "CellID",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "donor_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "library_preparation_protocol",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "library_preparation_protocol__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "organ",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "organ__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "sex",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "species",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "species__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "bmi",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "cell_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "cell_type__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "culture_duration",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "culture_duration__unit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "culture_duration__unit_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "development_stage",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "development_stage__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease__intracellular_pathogen",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease__intracellular_pathogen__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease__time_since_onset",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "disease__time_since_onset__unit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "disease__time_since_onset__unit_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease__time_since_treatment_start",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "disease__time_since_treatment_start__unit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "disease__time_since_treatment_start__unit_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease__treated",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "disease__treatment",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "end_bias",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "enrichment__cell_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "enrichment__cell_type__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "enrichment__facs_markers",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "enrichment_method",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "ethnicity",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "ethnicity__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "gene_perturbation",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "gene_perturbation__direction",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "gene_perturbation__dynamics",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "gene_perturbation__method",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "gene_perturbation__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "geographical_region",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "geographical_region__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "growth_factor_perturbation",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "growth_factor_perturbation__concentration",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "growth_factor_perturbation__concentration__unit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "growth_factor_perturbation__concentration__unit_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "growth_factor_perturbation__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "growth_factor_perturbation__solvent",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "growth_factor_perturbation__source",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "is_living",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "mhc_genotype",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "mouse_strain",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "mouse_strain__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "number_of_reads",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "organism_age",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "organism_age__unit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "organism_age__unit_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "paired_ends",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "preservation_method",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "primer",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "race",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "race__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "read_length",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "sequencing_instrument_manufacturer_model",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "sequencing_instrument_manufacturer_model__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "small_molecule_perturbation",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "small_molecule_perturbation__concentration",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "small_molecule_perturbation__concentration__unit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "small_molecule_perturbation__concentration__unit_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "small_molecule_perturbation__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "small_molecule_perturbation__solvent",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "small_molecule_perturbation__source",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "spike_in_concentration",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "spike_in_kit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "strand",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "vaccination",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "vaccination__adjuvants",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "vaccination__dosage",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "vaccination__ontology_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "vaccination__route",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "vaccination__time_since",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "vaccination__time_since__unit",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "vaccination__time_since__unit_label",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "study_accession",
+        "type": "string"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "file_id",
+        "type": "string"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "metadata_convention_version",
+        "type": "string"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "organism_age__seconds",
+        "type": "float"
+    }
+]

--- a/schema/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.bq_schema.json
+++ b/schema/alexandria_convention/snapshot/2.0.0/alexandria_convention_schema.bq_schema.json
@@ -440,7 +440,7 @@
         "type": "string"
     },
     {
-        "mode": "REQUIRED",
+        "mode": "NULLABLE",
         "name": "metadata_convention_version",
         "type": "string"
     },

--- a/schema/alexandria_convention/snapshot/2.0.0/scp_bq_inputs.json
+++ b/schema/alexandria_convention/snapshot/2.0.0/scp_bq_inputs.json
@@ -9,7 +9,7 @@
   ],
   "metadata_convention_version": [
     "string",
-    "REQUIRED"
+    "NULLABLE"
   ],
   "organism_age__seconds": [
     "float",

--- a/schema/alexandria_convention/snapshot/2.0.0/scp_bq_inputs.json
+++ b/schema/alexandria_convention/snapshot/2.0.0/scp_bq_inputs.json
@@ -1,0 +1,18 @@
+{
+  "study_accession": [
+    "string",
+    "REQUIRED"
+  ],
+  "file_id": [
+    "string",
+    "REQUIRED"
+  ],
+  "metadata_convention_version": [
+    "string",
+    "REQUIRED"
+  ],
+  "organism_age__seconds": [
+    "float",
+    "NULLABLE"
+  ]
+}

--- a/tests/test_serialize_convention.py
+++ b/tests/test_serialize_convention.py
@@ -22,7 +22,7 @@ from serialize_convention import (
     create_parser,
     build_schema_info,
     serialize_convention,
-    write_schema,
+    write_convention_schema,
 )
 
 
@@ -45,7 +45,7 @@ class TestValidateMetadata(unittest.TestCase):
         output_fullpath = 'output_convention.json'
         schema_info = build_schema_info(project, version)
         convention = serialize_convention(schema_info, input_tsv)
-        write_schema(convention, output_fullpath)
+        write_convention_schema(convention, output_fullpath)
         with open("output_convention.json", "r") as result:
             generated_convention = json.load(result)
         os.remove("output_convention.json")


### PR DESCRIPTION
BigQuery schema JSON generation now automatically occurs with metadata convention JSON generation. The script expects both convention input TSV and an scp_bq_inputs.json file in a snapshots directory under schema/&lt;project&gt;_convention/snapshot.

Generate schema file using:
`python serialize_convention.py <project> <version>`

This satisfies SCP-2289