### PR TITLE
Handle nan __ontology_label values (SCP-2375)

### DIFF
--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -66,7 +66,7 @@ class DataArray:
         if len(self.values) > self.MAX_ENTRIES:
             values = self.values
             for idx, i in enumerate(range(0, len(self.values), self.MAX_ENTRIES)):
-                self.values = values[i: i + self.MAX_ENTRIES]
+                self.values = values[i : i + self.MAX_ENTRIES]
                 self.array_index = idx
                 yield copy.copy(self.__dict__)
         else:
@@ -76,8 +76,7 @@ class DataArray:
 class IngestFiles:
     # General logger for class
     info_logger = setup_logger(__name__, "info.txt")
-    error_logger = setup_logger(
-        __name__ + "_errors", "errors.txt", level=logging.ERROR)
+    error_logger = setup_logger(__name__ + "_errors", "errors.txt", level=logging.ERROR)
 
     def __init__(self, file_path, allowed_file_types):
         self.file_path = file_path
@@ -293,8 +292,7 @@ class IngestFiles:
 
     def open_tsv(self, opened_file_object, **kwargs):
         """Opens tsv file"""
-        csv.register_dialect("tsvDialect", delimiter="\t",
-                             skipinitialspace=True)
+        csv.register_dialect("tsvDialect", delimiter="\t", skipinitialspace=True)
         return csv.reader(opened_file_object, dialect="tsvDialect")
 
     def extract_csv_or_tsv(self, file):

--- a/tests/data/issues_array_v2.0.0.json
+++ b/tests/data/issues_array_v2.0.0.json
@@ -38,9 +38,6 @@
     "ontology": {
       "organ: No match found in EBI OLS for provided ontology ID: nan": [
         "BM01_16dpp_TAAGCAGTGGTA"
-      ],
-      "organ: input ontology_label \"nan\" does not match EBI OLS lookup \"milk\",": [
-        "BM01_16dpp_CCGAATTCACCG"
       ]
     }
   },
@@ -48,6 +45,7 @@
     "ontology": {
       "disease__time_since_onset__unit: no ontology label supplied in metadata file for \"UO_0000035\" - no cross-check for data entry error possible": null,
       "disease__time_since_onset__unit: no ontology label supplied in metadata file for \"UO_0000033\" - no cross-check for data entry error possible": null,
+      "organ: no ontology label supplied in metadata file for \"UBERON_0001913\" - no cross-check for data entry error possible": null,
       "ethnicity: no ontology label supplied in metadata file for \"HANCESTRO_0005\" - no cross-check for data entry error possible": null
     }
   }


### PR DESCRIPTION
Handle edge case where metadata file provides an __ontology_label column but does not provide values (prevent validation from making excessive EBI OLS calls due to bug by not catching this edge case).

For required metadata, JSON schema validation will fail because 'nan' is not a string - apparently supplying nan does not count as violating the "required" constraint. Note that for optional metadata, nan values are not passed in JSON Schema for validation, only a cross-check warning will be emitted.

This commit includes updates to a reference test output file so reference matches new parse behavior.

This satisfies SCP-2375