### PR TITLE
Pass delimiter into sniffer

### DIFF
--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -273,10 +273,17 @@ class IngestFiles:
         """Opens file as a dataframe """
         open_file_object = kwargs.pop('open_file_object')
         if file_type in self.allowed_file_types:
-            csv_dialect = csv.Sniffer().sniff(open_file_object.readline())
-            csv_dialect.skipinitialspace = True
+            # Determine delimiter based on file type
+            if file_type == "text/tab-separated-values":
+                delimiter = "\t"
+            elif file_type == "text/csv":
+                delimiter = ","
+            else:
+                delimiter = None
+            dialect = csv.Sniffer().sniff(open_file_object.readline(), delimiters=delimiter)
+            dialect.skipinitialspace = True
             open_file_object.seek(0)
-            return pd.read_csv(file_path, dialect=csv_dialect, **kwargs)
+            return pd.read_csv(file_path, dialect=dialect, **kwargs)
         else:
             raise ValueError("File must be tab or comma delimited")
 


### PR DESCRIPTION
The last [PR](https://github.com/broadinstitute/scp-ingest-pipeline/pull/85) submitted to correct the numeric group labels did not account for metadata conventions that have array based data. This caused ingest to throw error ``` csv.Error: Could not determine delimiter```.  To correct this, the known delimiter is passed into the CSV sniffer. 

Command used

```
python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_cell_metadata --cell-metadata-file /Users/eaugusti/scp-ingest-pipeline/tests/data/valid_array_v1.1.3.tsv --study-accession SCP123 --ingest-cell-metadata
```

Automated test pass. Further testing in staging will need to be conducted to verify this PR satisfies [2214](https://broadworkbench.atlassian.net/browse/SCP-2214) 