### PR TITLE
Publish scp-ingest-pipeline to PyPI (SCP-2471)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ build
 .vscode/
 *.sublime-project
 *.sublime-workspace
-@.code-workspace
+*.code-workspace
 
 # Ignore other detritus
 *.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-google-cloud-storage==1.16.1
-google-cloud-bigquery==1.21.0
+google-cloud-storage==1.28.1
+google-cloud-bigquery==1.24.0
 requests==2.22.0
 numpy==1.16.4
 scipy==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='scp-ingest-pipe',
-    version='1.3.6rc1',
+    name='scp-ingest-pipeline',
+    version='1.3.7rc1',
     description='ETL pipeline for single-cell RNA-seq data',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='scp-ingest-pipeline',
-    version='1.3.7rc1',
+    version='1.3.7',
     description='ETL pipeline for single-cell RNA-seq data',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setup(
@@ -8,7 +8,8 @@ setup(
     version='1.3.7rc1',
     description='ETL pipeline for single-cell RNA-seq data',
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type='text/markdown',
+    url='https://github.com/broadinstitute/scp-ingest-pipeline',
     author='Single Cell Portal team',
     author_email='scp-support@broadinstitute.zendesk.com',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 from setuptools import setup, find_packages
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
-    name='scp_ingest_pipeline',
-    version='0.1',
+    name='scp-ingest-pipe',
+    version='1.3.6rc1',
     description='ETL pipeline for single-cell RNA-seq data',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author='Single Cell Portal team',
     author_email='scp-support@broadinstitute.zendesk.com',
     install_requires=[
@@ -24,8 +30,15 @@ setup(
         'opencensus-context',
         'opencensus-ext-stackdriver',
         'google-cloud-trace',
-	'grpcio',
-	'grpcio-tools'
+        'grpcio',
+        'grpcio-tools',
     ],
     packages=find_packages(),
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: BSD License',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+        'Programming Language :: Python :: 3.7',
+    ],
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
Minor updates to publish scp-ingest-pipeline to PyPI

These changes support SCP-2471. 