### PR TITLE
add grpcio dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 google-cloud-storage==1.28.1
 google-cloud-bigquery==1.24.0
+grpcio==1.29.0
 requests==2.22.0
 numpy==1.16.4
 scipy==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='scp-ingest-pipeline',
-    version='1.3.7',
+    version='1.3.8',
     description='ETL pipeline for single-cell RNA-seq data',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Previous build failed CI, docker container missing grpc package. Adding explicitly to requirements.txt to ensure the dependency is included in our docker image.

This supports testing SCP-2424 and SCP-2396 in staging.