### PR TITLE
addressing off-by-one error when aligning cell names w/ scores (SCP-2656)

### DIFF
--- a/ingest/expression_files/dense_ingestor.py
+++ b/ingest/expression_files/dense_ingestor.py
@@ -105,7 +105,8 @@ class DenseIngestor(GeneExpression, IngestFiles):
                         float(expression_score)
                     ):
                         valid_expression_scores.append(expression_score)
-                        associated_cells.append(cells[idx])
+                        # add one to account for gene name in scores list
+                        associated_cells.append(cells[idx + 1])
             except Exception:
                 raise ValueError("Score '{expression_score}' is not valid")
         return valid_expression_scores, associated_cells
@@ -180,7 +181,7 @@ class DenseIngestor(GeneExpression, IngestFiles):
         # Represents row as a list
         for row in self.csv_file_handler:
             valid_expression_scores, cells = DenseIngestor.filter_expression_scores(
-                row[1:], self.header[1:]
+                row[1:], self.header
             )
             numeric_scores = DenseIngestor.process_row(valid_expression_scores)
             gene = row[0]

--- a/ingest/expression_files/dense_ingestor.py
+++ b/ingest/expression_files/dense_ingestor.py
@@ -180,7 +180,7 @@ class DenseIngestor(GeneExpression, IngestFiles):
         # Represents row as a list
         for row in self.csv_file_handler:
             valid_expression_scores, cells = DenseIngestor.filter_expression_scores(
-                row[1:], self.header
+                row[1:], self.header[1:]
             )
             numeric_scores = DenseIngestor.process_row(valid_expression_scores)
             gene = row[0]

--- a/ingest/expression_files/dense_ingestor.py
+++ b/ingest/expression_files/dense_ingestor.py
@@ -92,7 +92,7 @@ class DenseIngestor(GeneExpression, IngestFiles):
         """
         associated_cells = []
         valid_expression_scores = []
-        for idx, expression_score in enumerate(scores, 1):
+        for idx, expression_score in enumerate(scores):
             try:
                 if (
                     expression_score != "0"


### PR DESCRIPTION
Correcting an issue where the arrays of cell names and expression values parsed for an individual gene from a dense matrix do not line up, causing the first expression value to be lost, and the final cell name to have a `nil` expression value.

This PR satisfies SCP-2656.