### PR TITLE
addressing off by one error when rounding expression values (SCP-2656)

### DIFF
--- a/ingest/expression_files/dense_ingestor.py
+++ b/ingest/expression_files/dense_ingestor.py
@@ -77,7 +77,7 @@ class DenseIngestor(GeneExpression, IngestFiles):
             # Convert string to float and round 3 places
             return round(float(value), 3)
 
-        result = map(convert_to_float, row[1:])
+        result = map(convert_to_float, row)
         return list(result)
 
     @staticmethod

--- a/tests/test_dense.py
+++ b/tests/test_dense.py
@@ -42,12 +42,12 @@ class TestDense(unittest.TestCase):
 
     def test_process_row(self):
         # Positive test case
-        valid_row = ["BRCA1", "' 1.45678 '", '"3.45678"', "2"]
+        valid_row = ["' 1.45678 '", '"3.45678"', "2"]
         processed_row = DenseIngestor.process_row(valid_row)
         self.assertEqual([1.457, 3.457, 2.0], processed_row)
 
         # Negative test case
-        invalid_row = ["BRCA1", "' 1.BRCA1 '", '"3.45678"', "2"]
+        invalid_row = ["' 1.BRCA1 '", '"3.45678"', "2"]
         self.assertRaises(ValueError, DenseIngestor.process_row, invalid_row)
 
     def test_has_gene_keyword(self):


### PR DESCRIPTION
When rounding expression values to 3 digits, we are unintentionally dropping the first value.  The gene name has already been removed from this list in `filter_expression_scores`, so calling `row[1:]` is not needed.

This PR satisfies SCP-2656.