### PR TITLE
Fix query to detect duplicate cells across expression matrices within a study (SCP-2674)

### DIFF
--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -81,7 +81,8 @@ class GeneExpression:
                 {"linear_data_type": "Study"},
                 {"array_type": "cells"},
                 {"study_id": study_id},
-            ]
+            ],
+            "$nor": [{"name": "All Cells"}],
         }
         # Returned fields from query results
         field_names = {"values": 1, "_id": 0}
@@ -164,7 +165,8 @@ class GeneExpression:
         self.insert(gene_docs, self.COLLECTION_NAME)
         self.insert(data_array_docs, "data_arrays")
         self.info_logger.info(
-            f"Time to load {len(gene_docs) + len(data_array_docs)} models: {str(datetime.datetime.now() - start_time)}"
+            f"Time to load {len(gene_docs) + len(data_array_docs)} models: {str(datetime.datetime.now() - start_time)}",
+            extra=self.extra_log_params,
         )
 
     def insert(self, docs: List, collection_name: str):

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -1,4 +1,3 @@
-import abc
 import os
 
 from pymongo import MongoClient
@@ -25,7 +24,7 @@ class MongoConnection:
                 authSource=self.db_name,
                 authMechanism='SCRAM-SHA-1',
             )
-            self._client=client[self.db_name]
+            self._client = client[self.db_name]
         # Needed to due to lack of database mock library for MongoDB
         # TODO: add mock, remove this
         else:

--- a/ingest/monitor.py
+++ b/ingest/monitor.py
@@ -117,14 +117,14 @@ def integrate_sentry():
         return
 
     sentry_logging = LoggingIntegration(
-        level=logging.ERROR,       # Capture error and above as breadcrumbs
-        event_level=logging.ERROR  # Send errors as events
+        level=logging.ERROR,  # Capture error and above as breadcrumbs
+        event_level=logging.ERROR,  # Send errors as events
     )
     sentry_sdk.init(
         dsn=sentry_DSN,
         integrations=[sentry_logging],
         attach_stacktrace=True,
-        before_send=before_send_to_sentry
+        before_send=before_send_to_sentry,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='scp-ingest-pipeline',
-    version='1.5.4',
+    version='1.5.6',
     description='ETL pipeline for single-cell RNA-seq data',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -32,7 +32,7 @@ setup(
         'opencensus-ext-stackdriver',
         'google-cloud-trace',
         'grpcio',
-        'sentry-sdk'
+        'sentry-sdk',
     ],
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
This PR fixes the query for obtaining the known cells in expression matrices within a study. In the current code, if a dense matrix is parsed after a metadata file, it will always fail validation because the query used to get the arrays of cells from other matrix files in that study contains the "all cells" arrays from metadata files.

This satisfies SCP-2674.