### PR TITLE
Fix client and function name

### DIFF
--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -192,4 +192,4 @@ class Clusters(Annotations):
         # Merge BASE_DICT, cluster_attr & data_array_attr and return DataArray model
         return DataArray(
             **data_array_attr, **cluster_attr, **BASE_DICT
-        ).get_data_array()
+        ).get_data_arrays()

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -180,7 +180,7 @@ class GeneExpression:
 
     def load(self, docs: List, collection_name: List):
         start_time = datetime.datetime.now()
-        GeneExpression.insert(docs, collection_name, self.mongo_connection)
+        GeneExpression.insert(docs, collection_name, self.mongo_connection._client)
         GeneExpression.dev_logger.info(
             f"Time to load {len(docs)} models: {str(datetime.datetime.now() - start_time)}"
         )


### PR DESCRIPTION
fix
```
 'DataArray' object has no attribute 'get_data_array' 
```
and 
```
5f495049421aa91245db022d.__main___errors.ingest_expression:318:None] Error caused by inserting into collection 'genes': 'MongoConnection' object is not subscriptable
```