### PR TITLE
*SCP-2746 Change logger level for cell metadata form validation

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -321,7 +321,7 @@ class IngestPipeline:
         """Ingests cell metadata files into Firestore."""
         self.cell_metadata.preprocess()
         if self.cell_metadata.validate():
-            IngestPipeline.dev_logger.error("Cell metadata file format valid")
+            IngestPipeline.dev_logger.info("Cell metadata file format valid")
             # Check file against metadata convention
             if self.kwargs["validate_convention"] is not None:
                 if self.kwargs["validate_convention"]:


### PR DESCRIPTION
[1889670378](https://sentry.io/organizations/broad-institute/issues/1889670378/?project=1424198&query=is%3Aunresolved)- We're reporting when cell metadata format is valid with logger.error when it should be reported with logger.info. Because it's reported with logger.error it's being reported in sentry when it shouldn't. 