### PR TITLE
Return metadata convention validation error messages to user (SCP-2739)

### DIFF
--- a/scripts/ingest_stress_test.py
+++ b/scripts/ingest_stress_test.py
@@ -35,7 +35,7 @@ DATA = {
     "medium": {
         "dense": "gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/scp-ingest-pipeline/stress_test_data/medium_expr.txt.gz",
         "cluster": "gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/scp-ingest-pipeline/stress_test_data/medium_coords.txt",
-        "metadata": "gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/scp-ingest-pipeline/stress_test_data/medium/metadata.txt",
+        "metadata": "gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/scp-ingest-pipeline/stress_test_data/medium_metadata.txt",
     },
     # matrix has ~220K cells, ~16K genes
     # baseline ingest for dense ~25.5m

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -62,6 +62,7 @@ class TestValidateMetadata(unittest.TestCase):
             'SCPtest',
             study_accession='SCPtest',
         )
+        # The following line should become metadata.validate() as part of bugfix SCP-2756
         metadata.validate_format()
         print(f"Format is correct {metadata.validate_format()}")
         return (metadata, convention)


### PR DESCRIPTION
Users of the metadata convention reported failed validation Notifier emails that had stack traces with "unexpected exit status 65 was not ignored" and no information on how to fix their metadata files.

This simple PR changes the metadata convention from using the dev_logger to using the user_logger.

The investigation for this ticket uncovered two issues:
1. ingest_pipeline is treating numeric array-based values as invalid non-numeric data and rejecting the file as format  invalid. Created SCP-2756 to deal address this problem. Tests for array-based validation did not reveal this problem because the tests were not using the newly abstracted file format checking functions.
2. running ingest_pipeline.py produces results different from validate_metadata.py because format validation has been abstracted to a higher level and ingest_pipeline catches format errors that occur upstream of validate_metadata activity. Fixing this issue will be much more straightforward when the issue above has been resolved and the metadata validation tests can use the abstracted file format checks.