### PR TITLE
Generate raw count synthetic data (SCP-2535)

### DIFF
--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -217,7 +217,6 @@ class MTXIngestor(GeneExpression):
             exp_cells.append(exp_cell)
             exp_scores.append(exp_score)
 
-
         # create gene entries for genes with no positive expression values
         for idx, gene in enumerate(self.genes):
             if not visited_expression_indices.get(idx + 1):

--- a/ingest/make_toy_data.py
+++ b/ingest/make_toy_data.py
@@ -12,6 +12,9 @@ python make_toy_data.py
 # Generate 6 dense matrix files, 2 MB each
 python make_toy_data.py --num-files 6 --size-per-file 2_MiB
 
+# Generate 1 raw counts dense matrix file, 2 MB
+python make_toy_data.py --num-files 1 --size-per-file 2_MiB --raw-count
+
 # Generate 1 dense matrix file named AB_meso.txt, 2 GB in raw size, then compress it
 python make_toy_data.py --num-files 1 --filename-leaf 'meso' --size-per-file 2_GiB --gzip
 
@@ -302,7 +305,6 @@ def get_signature_content(
 
         # actual generator portion
         for i, group_of_genes in enumerate(split_seq(genes, num_chunks)):
-            np.random.seed(12345)
             expr = []
             gene_row = np.asarray([group_of_genes])
             # generate random scores with dimension (num_genes_in_chunk, num_cells)

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -15,6 +15,7 @@ import unittest
 
 from unittest.mock import patch
 import sys
+import shutil
 from random import randrange
 from glob import glob
 
@@ -60,6 +61,13 @@ class GenomesTestCase(unittest.TestCase):
         parse_genome_annotations(parsed_args)
         return
 
+    @staticmethod
+    def clean_up(output_dir):
+        try:
+            shutil.rmtree(output_dir)
+        except OSError:
+            print('no files to remove')
+
     def test_genomes_default(self):
         """Genomes Pipeline should extract and transform reference data
         """
@@ -69,3 +77,5 @@ class GenomesTestCase(unittest.TestCase):
         # There should be two gzipped GTF files
         gzipped_gtfs = glob(f'{output_dir}*.gtf.gz')
         self.assertEqual(len(gzipped_gtfs), 2)
+
+        self.clean_up(output_dir)

--- a/tests/test_make_toy.py
+++ b/tests/test_make_toy.py
@@ -8,6 +8,7 @@ See See https://github.com/broadinstitute/scp-ingest-pipeline#test.
 
 import unittest
 import sys
+import shutil
 from random import randrange
 
 sys.path.append('../ingest')
@@ -25,6 +26,14 @@ class MakeToyTestCase(unittest.TestCase):
         make_toy_data(parsed_args)
         return
 
+    @staticmethod
+    def clean_up(output_dir):
+        try:
+            shutil.rmtree(output_dir)
+        except OSError:
+            print('no files to remove')
+
     def test_make_toy_data_default(self):
         args = ['--output-dir', output_dir]
         self.execute_make_toy(args)
+        self.clean_up(output_dir)


### PR DESCRIPTION
Modify make_toy_data.py to generate raw count (integer expression values) synthetic data. Also, for test_make_toy and test_genomes, delete output files when tests have completed.

This work supports SCP-2535.