### PR TITLE
address invalid baseURI from EBI OLS for NCBITaxon (SCP-2820)

### DIFF
--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -217,7 +217,6 @@ class MTXIngestor(GeneExpression):
             exp_cells.append(exp_cell)
             exp_scores.append(exp_score)
 
-
         # create gene entries for genes with no positive expression values
         for idx, gene in enumerate(self.genes):
             if not visited_expression_indices.get(idx + 1):

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -234,6 +234,9 @@ class OntologyRetriever:
 
         if convention_ontology and metadata_ontology:
             base_term_uri = metadata_ontology["config"]["baseUris"][0]
+            # temporary workaround for invald baseURI returned from EBI OLS for NCBITaxon (SCP-2820)
+            if base_term_uri == "http://purl.obolibrary.org/obo/NCBITAXON_":
+                base_term_uri = "http://purl.obolibrary.org/obo/NCBITaxon_"
             query_iri = encode_term_iri(term_id, base_term_uri)
 
             term_url = convention_ontology["_links"]["terms"]["href"] + "/" + query_iri


### PR DESCRIPTION
Metadata validation for NCBITaxon terms began failing on 10/14. Our term validation requests were requesting validation for NCBITAXON_XXXX terms which fail. The requests are formed using the baseURI supplied by EBI OLS. When converted to a baseURI with NCBITaxon_ instead of NCBITAXON, the validation requests succeed.

This PR adds a temporary workaround to correct the invalid baseURI we're obtaining from EBI OLS.

This resolves the bug described in SCP-2820.