### PR TITLE
increment for PyPI release (SCP-2840)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='scp-ingest-pipeline',
-    version='1.5.6',
+    version='1.6.5',
     description='ETL pipeline for single-cell RNA-seq data',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Functionality from scp-ingest-pipeline release 1.6.4 is needed for successful CI builds in the single_cell_portal repo. This PR formalizes the release of that functionality to a PyPI release.

To simplify PyPI release in future, Development -> Master PRs should modify setup.py to increment the version number so the codebase is release-to-PyPI-ready.

Note: CI build failures for the PR are false positives as the Ensembl API is currently has degraded performance.

This work supports the PyPI release specified in SCP-2840.