### PR TITLE
remove loompy from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pandas==1.1.3
 pandocfilters==1.4.2
 mypy-extensions==0.4.1
 dataclasses==0.6
-loompy==3.0.6
 colorama==0.4.1
 pymongo==3.9.0
 backoff==1.10.0


### PR DESCRIPTION
pinning loompy to a newer version caused issues with cloud build. Verified that loompy is currently not needed and confirmed that --no-cache docker builds without loompy succeed locally.