### PR TITLE
* SCP-2796 Fix URL for Bard

### DIFF
--- a/ingest/monitoring/metrics_service.py
+++ b/ingest/monitoring/metrics_service.py
@@ -45,7 +45,7 @@ class MetricsService:
     def post_event(props):
         try:
             r = requests.post(
-                f"{MetricsService.BARD_HOST_URL}api/event",
+                f"{MetricsService.BARD_HOST_URL}/api/event",
                 headers={"content-type": "application/json"},
                 data=props,
             )

--- a/ingest/monitoring/metrics_service.py
+++ b/ingest/monitoring/metrics_service.py
@@ -45,7 +45,7 @@ class MetricsService:
     def post_event(props):
         try:
             r = requests.post(
-                MetricsService.BARD_HOST_URL,
+                f"{MetricsService.BARD_HOST_URL}api/event",
                 headers={"content-type": "application/json"},
                 data=props,
             )
@@ -57,6 +57,6 @@ class MetricsService:
             MetricsService.dev_logger.exception(e)
         except requests.exceptions.RequestException as e:
             # Catastrophic error
-            MetricsService.dev_logger.critcal(e)
+            MetricsService.dev_logger.exception(e)
         except Exception as e:
             MetricsService.dev_logger.exception(e)


### PR DESCRIPTION
An incorrect URL from ingest pipeline was causing [build errors](https://travis-ci.com/github/broadinstitute/single_cell_portal_core/builds/201355050#L2935) when releasing scp_core. This PR addresses the issue by appending the endpoint to the base URL. 