### PR TITLE
* SCP-2900 Resolve "not enough values to unpack (expected 3, got 1)"

### DIFF
--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -125,7 +125,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
             # numeric(-n). Use stable sort (--stable) so that columns are only compared by the first column.
             # Without this argument line '1 3 4' and ' 1 5 4' would be considered unsorted.
             p2 = subprocess.run(
-                ["sort", "-s", "-c", "--stable", "-n", "-k", "1,1"],
+                ["sort", "-c", "--stable", "-n", "-k", "1,1"],
                 stdin=p1.stdout,
                 capture_output=True,
             )

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -192,14 +192,17 @@ class MTXIngestor(GeneExpression, IngestFiles):
             i (IO): Line number where data starts
         """
         for count, line in enumerate(file_handler):
-            try:
-                line_values = line.split()
-                float(line_values[0])
-                # First line w/o '%' is mtx dimension. So skip this line (+1)
-                count += 2
-                return count
-            except ValueError:
-                pass
+            if not line.startswith("%"):
+                try:
+                    line_values = line.split()
+                    float(line_values[0])
+                    # First line w/o '%' is mtx dimension. So skip this line (+1)
+                    count += 2
+                    return count
+                except ValueError:
+                    raise ValueError(
+                        "Only header, comment lines starting with '%', and numeric data allowed in MTX file."
+                    )
         raise ValueError(
             "MTX file did not contain expression data. Please check formatting and contents of file."
         )
@@ -207,14 +210,15 @@ class MTXIngestor(GeneExpression, IngestFiles):
     @staticmethod
     def get_mtx_dimensions(file_handler) -> List:
         for line in file_handler:
-            if not line.startswith("%"):
-                mtx_dimensions: List[str] = line.strip().split()
-                try:
-                    # Convert values in mtx_dimensions to int
-                    dimensions = list(map(int, mtx_dimensions))
-                    return dimensions
-                except Exception as e:
-                    raise e
+            if not line.strip():
+                if not line.startswith("%"):
+                    mtx_dimensions: List[str] = line.strip().split()
+                    try:
+                        # Convert values in mtx_dimensions to int
+                        dimensions = list(map(int, mtx_dimensions))
+                        return dimensions
+                    except Exception as e:
+                        raise e
         raise ValueError("MTX file did not contain data")
 
     @staticmethod

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -204,7 +204,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
                         "Only header, comment lines starting with '%', and numeric data allowed in MTX file."
                     )
                 except IndexError:
-                    raise IndexError("MTX file can not start with a space")
+                    raise IndexError("MTX file cannot start with a space")
         raise ValueError(
             "MTX file did not contain expression data. Please check formatting and contents of file."
         )

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -191,16 +191,15 @@ class MTXIngestor(GeneExpression, IngestFiles):
          ----------
             i (IO): Line number where data starts
         """
-        i = 0
-        for line in file_handler:
+        for count, line in enumerate(file_handler):
             try:
                 line_values = line.split()
                 float(line_values[0])
                 # First line w/o '%' is mtx dimension. So skip this line (+1)
-                i += 2
-                return i
+                count += 2
+                return count
             except ValueError:
-                i += 1
+                pass
         raise ValueError(
             "MTX file did not contain expression data. Please check formatting and contents of file."
         )

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -194,7 +194,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
         for count, line in enumerate(file_handler):
             if not line.startswith("%"):
                 try:
-                    line_values = line.split()
+                    line_values = line.strip().split()
                     float(line_values[0])
                     # First line w/o '%' is mtx dimension. So skip this line (+1)
                     count += 2
@@ -203,6 +203,8 @@ class MTXIngestor(GeneExpression, IngestFiles):
                     raise ValueError(
                         "Only header, comment lines starting with '%', and numeric data allowed in MTX file."
                     )
+                except IndexError:
+                    raise IndexError("MTX file can not start with a space")
         raise ValueError(
             "MTX file did not contain expression data. Please check formatting and contents of file."
         )

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -212,15 +212,14 @@ class MTXIngestor(GeneExpression, IngestFiles):
     @staticmethod
     def get_mtx_dimensions(file_handler) -> List:
         for line in file_handler:
-            if not line.strip():
-                if not line.startswith("%"):
-                    mtx_dimensions: List[str] = line.strip().split()
-                    try:
-                        # Convert values in mtx_dimensions to int
-                        dimensions = list(map(int, mtx_dimensions))
-                        return dimensions
-                    except Exception as e:
-                        raise e
+            if not line.startswith("%"):
+                mtx_dimensions: List[str] = line.strip().split()
+                try:
+                    # Convert values in mtx_dimensions to int
+                    dimensions = list(map(int, mtx_dimensions))
+                    return dimensions
+                except Exception as e:
+                    raise e
         raise ValueError("MTX file did not contain data")
 
     @staticmethod

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -207,19 +207,16 @@ class MTXIngestor(GeneExpression, IngestFiles):
 
     @staticmethod
     def get_mtx_dimensions(file_handler) -> List:
-        i = 0
         for line in file_handler:
-            try:
-                line_values = line.split()
-                float(line_values[0])
-                # First line w/o '%' is mtx dimension. So skip this line (+1)
-                i += 2
-                return i
-            except ValueError:
-                i += 1
-        raise ValueError(
-            "MTX file did not contain expression data. Please check formatting and contents of file."
-        )
+            if not line.startswith("%"):
+                mtx_dimensions: List[str] = line.strip().split()
+                try:
+                    # Convert values in mtx_dimensions to int
+                    dimensions = list(map(int, mtx_dimensions))
+                    return dimensions
+                except Exception as e:
+                    raise e
+        raise ValueError("MTX file did not contain data")
 
     @staticmethod
     def get_features(feature_row: str):

--- a/tests/data/mtx/bad_format_has_character.mtx
+++ b/tests/data/mtx/bad_format_has_character.mtx
@@ -1,0 +1,12 @@
+%%MatrixMarket matrix coordinate real general
+%
+%
+aaggg
+ggff
+80 272 4352
+2 8 2.32
+2 9 2.81
+4 14 2.58
+3 18 1.58
+3 20 2.0
+3 21 3.0

--- a/tests/data/mtx/bad_format_has_space.mtx
+++ b/tests/data/mtx/bad_format_has_space.mtx
@@ -1,4 +1,3 @@
-
 %%MatrixMarket matrix coordinate real general
 %
 %

--- a/tests/data/mtx/bad_format_has_space.mtx
+++ b/tests/data/mtx/bad_format_has_space.mtx
@@ -1,0 +1,12 @@
+
+%%MatrixMarket matrix coordinate real general
+%
+%
+
+80 272 4352
+2 8 2.32
+2 9 2.81
+4 14 2.58
+3 18 1.58
+3 20 2.0
+3 21 3.0

--- a/tests/data/mtx/mtx_character_before_data.mtx
+++ b/tests/data/mtx/mtx_character_before_data.mtx
@@ -1,8 +1,0 @@
-%%MatrixMarket matrix coordinate real general
-a
-/
-80 272 4352
-2 8 2.32
-2 9 2.81
-4 14 2.58
-3 18 1.58

--- a/tests/data/mtx/mtx_character_before_data.mtx
+++ b/tests/data/mtx/mtx_character_before_data.mtx
@@ -1,0 +1,8 @@
+%%MatrixMarket matrix coordinate real general
+a
+/
+80 272 4352
+2 8 2.32
+2 9 2.81
+4 14 2.58
+3 18 1.58

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -93,6 +93,8 @@ class TestMTXIngestor(unittest.TestCase):
         mtx_file_handler = open("data/mtx/unsorted_mtx.mtx.txt")
         self.assertEqual(3, MTXIngestor.get_data_start_line_number(mtx_file_handler))
 
+        mtx_file_handler = open("data/mtx/mtx_character_before_data.mtx")
+        self.assertEqual(5, MTXIngestor.get_data_start_line_number(mtx_file_handler))
         # Test for empty file
         empty_file_handler = open("data/empty_file.txt")
         self.assertRaises(

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -93,10 +93,16 @@ class TestMTXIngestor(unittest.TestCase):
         mtx_file_handler = open("data/mtx/unsorted_mtx.mtx.txt")
         self.assertEqual(3, MTXIngestor.get_data_start_line_number(mtx_file_handler))
 
-        mtx_file_handler = open("data/mtx/mtx_character_before_data.mtx")
+        mtx_file_handler = open("data/mtx/bad_format_has_character.mtx")
         self.assertRaises(
             ValueError, MTXIngestor.get_data_start_line_number, mtx_file_handler
         )
+
+        mtx_file_handler = open("data/mtx/bad_format_has_space.mtx")
+        self.assertRaises(
+            IndexError, MTXIngestor.get_data_start_line_number, mtx_file_handler
+        )
+
         # Test for empty file
         empty_file_handler = open("data/empty_file.txt")
         self.assertRaises(

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -94,7 +94,9 @@ class TestMTXIngestor(unittest.TestCase):
         self.assertEqual(3, MTXIngestor.get_data_start_line_number(mtx_file_handler))
 
         mtx_file_handler = open("data/mtx/mtx_character_before_data.mtx")
-        self.assertEqual(5, MTXIngestor.get_data_start_line_number(mtx_file_handler))
+        self.assertRaises(
+            ValueError, MTXIngestor.get_data_start_line_number, mtx_file_handler
+        )
         # Test for empty file
         empty_file_handler = open("data/empty_file.txt")
         self.assertRaises(


### PR DESCRIPTION
PR addresses valid MTX files with an empty comment line after the expected header causing "not enough values to unpack (expected 3, got 1)" in production.