### PR TITLE
* SCP-2949 Fix query for processed matrices

### DIFF
--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -212,6 +212,7 @@ class GeneExpression:
                 {"expression_file_info": None},
             ]
         else:
+            # Raw counts need appendage
             QUERY["$and"].append(
                 {"expression_file_info.is_raw_counts": is_raw_count_files}
             )

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -206,13 +206,12 @@ class GeneExpression:
             study_id, current_study_file_id, client
         )
         if not is_raw_count_files:
-            # Legacy data entries will not have the embedede document 'expression_file_info'
+            # Legacy data entries will not have the embeded document 'expression_file_info'
             QUERY["$or"] = [
                 {"expression_file_info.is_raw_counts": is_raw_count_files},
                 {"expression_file_info": None},
             ]
         else:
-            # Raw counts need appendage
             QUERY["$and"].append(
                 {"expression_file_info.is_raw_counts": is_raw_count_files}
             )

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -205,7 +205,13 @@ class GeneExpression:
         is_raw_count_files = GeneExpression.is_raw_count_file(
             study_id, current_study_file_id, client
         )
-        if is_raw_count_files:
+        if not is_raw_count_files:
+            # Legacy data entries will not have the embedede document 'expression_file_info'
+            QUERY["$or"] = [
+                {"expression_file_info.is_raw_counts": is_raw_count_files},
+                {"expression_file_info": None},
+            ]
+        else:
             QUERY["$and"].append(
                 {"expression_file_info.is_raw_counts": is_raw_count_files}
             )

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -206,7 +206,7 @@ class GeneExpression:
             study_id, current_study_file_id, client
         )
         if not is_raw_count_files:
-            # Legacy data entries will not have the embeded document 'expression_file_info'
+            # Legacy data entries will not have the embedded document 'expression_file_info'
             QUERY["$or"] = [
                 {"expression_file_info.is_raw_counts": is_raw_count_files},
                 {"expression_file_info": None},

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -205,7 +205,12 @@ class GeneExpression:
         is_raw_count_files = GeneExpression.is_raw_count_file(
             study_id, current_study_file_id, client
         )
-        if not is_raw_count_files:
+        if is_raw_count_files:
+            QUERY["$and"].append(
+                {"expression_file_info.is_raw_counts": is_raw_count_files}
+            )
+
+        else:
             # Legacy data entries will not have the embedded document 'expression_file_info'
             QUERY["$and"].append(
                 {
@@ -215,11 +220,6 @@ class GeneExpression:
                     ]
                 }
             )
-        else:
-            QUERY["$and"].append(
-                {"expression_file_info.is_raw_counts": is_raw_count_files}
-            )
-        # Returned fields query results
         query_results = list(client[COLLECTION_NAME].find(QUERY, field_names))
         return query_results
 

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -207,10 +207,14 @@ class GeneExpression:
         )
         if not is_raw_count_files:
             # Legacy data entries will not have the embedded document 'expression_file_info'
-            QUERY["$or"] = [
-                {"expression_file_info.is_raw_counts": is_raw_count_files},
-                {"expression_file_info": None},
-            ]
+            QUERY["$and"].append(
+                {
+                    "$or": [
+                        {"expression_file_info.is_raw_counts": is_raw_count_files},
+                        {"expression_file_info": None},
+                    ]
+                }
+            )
         else:
             QUERY["$and"].append(
                 {"expression_file_info.is_raw_counts": is_raw_count_files}

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -291,10 +291,14 @@ class TestExpressionFiles(unittest.TestCase):
             "expression_files.expression_files.GeneExpression.is_raw_count_file",
             return_value=False,
         ):
-            RAW_COUNTS_QUERY["$or"] = [
-                {"expression_file_info.is_raw_counts": False},
-                {"expression_file_info": None},
-            ]
+            RAW_COUNTS_QUERY["$and"].append(
+                {
+                    "$or": [
+                        {"expression_file_info.is_raw_counts": False},
+                        {"expression_file_info": None},
+                    ]
+                }
+            )
             GeneExpression.get_study_expression_file_ids(
                 TestExpressionFiles.STUDY_ID,
                 TestExpressionFiles.STUDY_FILE_ID,

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -291,6 +291,10 @@ class TestExpressionFiles(unittest.TestCase):
             "expression_files.expression_files.GeneExpression.is_raw_count_file",
             return_value=False,
         ):
+            RAW_COUNTS_QUERY["$or"] = [
+                {"expression_file_info.is_raw_counts": False},
+                {"expression_file_info": None},
+            ]
             GeneExpression.get_study_expression_file_ids(
                 TestExpressionFiles.STUDY_ID,
                 TestExpressionFiles.STUDY_FILE_ID,


### PR DESCRIPTION
Ingest pipeline was not querying correctly to retrieve cell values for processed files. This was causing all cell values to be returned when a raw count file was ingested first. This PR fixes the issue. 