### PR TITLE
* SCP-2844 Exclude commented lines from unsorted MTX files

### DIFF
--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -309,7 +309,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
             # Cell names are the only data stored for raw counts.
             # Therefore, no need to determine if file is sorted or sort file.
             self.is_raw_count = True
-            self.transform()
+        self.transform()
 
     def extract_feature_barcode_matrices(self):
         """

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -183,6 +183,10 @@ class MTXIngestor(GeneExpression, IngestFiles):
     def get_data_start_line_number(file_handler: IO) -> int:
         """ Determines what line number data starts.
 
+        Parameters:
+        ___________
+            file_handler (IO): File handler of MTX file that contains headers.
+
          Returns
          ----------
             count (int): Line number where data starts

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -249,6 +249,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
          Returns
          ----------
             new_file_path (str) : Full path of newly sorted MTX file. This file does not contain original headers
+                or MTX dimensions.
         """
         file_name = os.path.basename(file_path)
         file_name = os.path.splitext(file_name)[0]

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -302,7 +302,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
                 self.mtx_file, self.mtx_path = self.resolve_path(new_mtx_file_path)
         else:
             # Cell names are the only data stored for raw counts.
-            # Therefore, no need to determine if file is sorted or sort files.
+            # Therefore, no need to determine if file is sorted or sort file.
             self.is_raw_count = True
             self.transform()
 

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -299,7 +299,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
             if not MTXIngestor.is_sorted(self.mtx_path, self.mtx_file):
                 new_mtx_file_path = MTXIngestor.sort_mtx(self.mtx_path, self.mtx_file)
                 # Reset mtx variables to newly sorted file
-                self.mtx_path, self.mtx_path = self.resolve_path(new_mtx_file_path)
+                self.mtx_file, self.mtx_path = self.resolve_path(new_mtx_file_path)
         else:
             # Cell names are the only data stored for raw counts.
             # Therefore, no need to determine if file is sorted or sort files.

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -117,7 +117,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
         return p1
 
     @staticmethod
-    def is_sorted(file_path: str, file_handler):
+    def is_sorted(file_path: str, file_handler: IO):
         """Checks if a file is sorted by gene index"""
         p1 = MTXIngestor.get_gene_expression_data(file_path, file_handler)
         try:
@@ -183,21 +183,19 @@ class MTXIngestor(GeneExpression, IngestFiles):
     def get_data_start_line_number(file_handler: IO) -> int:
         """ Determines what line number data starts.
 
-        Parameters:
-        ___________
-            file_handler (IO): File handler that points to top of MTX file
-
          Returns
          ----------
-            i (IO): Line number where data starts
+            count (int): Line number where data starts
         """
-        for count, line in enumerate(file_handler):
+        # Move file pointer to top of file
+        file_handler.seek(0, 0)
+        for count, line in enumerate(file_handler, start=1):
             if not line.startswith("%"):
                 try:
                     line_values = line.strip().split()
                     float(line_values[0])  # Determines if value is numeric
                     # First line w/o '%' is mtx dimension. So skip this line (+1)
-                    return count + 2
+                    return count + 1
                 except ValueError:
                     raise ValueError(
                         "Only header, comment lines starting with '%', and numeric data allowed in MTX file."
@@ -246,7 +244,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
 
          Returns
          ----------
-            new_file_path (str) : Full path of newly sorted MTX file
+            new_file_path (str) : Full path of newly sorted MTX file. This file does not contain original headers
         """
         file_name = os.path.basename(file_path)
         file_name = os.path.splitext(file_name)[0]
@@ -298,19 +296,15 @@ class MTXIngestor(GeneExpression, IngestFiles):
             self.study_id, self.study_file_id, self.mongo_connection._client
         ):
             self.is_raw_count = False
-            # Need fresh mtx file handler for get_data_start_line_number()
-            fresh_mtx_file_handler = self.resolve_path(self.mtx_path)[0]
-            if not MTXIngestor.is_sorted(self.mtx_path, fresh_mtx_file_handler):
-                new_mtx_file_path = MTXIngestor.sort_mtx(
-                    self.mtx_path, fresh_mtx_file_handler
-                )
+            if not MTXIngestor.is_sorted(self.mtx_path, self.mtx_file):
+                new_mtx_file_path = MTXIngestor.sort_mtx(self.mtx_path, self.mtx_file)
                 # Reset mtx variables to newly sorted file
-                self.mtx_file, self.mtx_path = self.resolve_path(new_mtx_file_path)
+                self.mtx_path, self.mtx_path = self.resolve_path(new_mtx_file_path)
         else:
             # Cell names are the only data stored for raw counts.
-            # Therefore, no need to sort files.
+            # Therefore, no need to determine if file is sorted or sort files.
             self.is_raw_count = True
-        self.transform()
+            self.transform()
 
     def extract_feature_barcode_matrices(self):
         """

--- a/tests/mock_data/expression/matrix_mtx/AB_toy_data_toy_unsorted_mtx_models.py
+++ b/tests/mock_data/expression/matrix_mtx/AB_toy_data_toy_unsorted_mtx_models.py
@@ -11266,7 +11266,6 @@ AB_toy_data_toy_unsorted_mtx_models = {
                 2.0,
                 2.81,
                 1.58,
-                4352.0,
                 2.81,
                 2.81,
                 1.0,

--- a/tests/mock_data/expression/matrix_mtx/AB_toy_data_toy_unsorted_mtx_models.py
+++ b/tests/mock_data/expression/matrix_mtx/AB_toy_data_toy_unsorted_mtx_models.py
@@ -11200,7 +11200,6 @@ AB_toy_data_toy_unsorted_mtx_models = {
                 "FoobarAB2_BazMoo_7DABDADBDBADACDB-1",
                 "FoobarAB5_BazMoo_2DDBCCDBADBADCBC-1",
                 "FoobarAB7_BazMoo_7BCABCCCACBAADDC-1",
-                "FoobarAB2_BazMoo_3BCDCBCCBCCCCBAC-1",
                 "FoobarAB2_BazMoo_8BDBABBACDCCDDBD-1",
                 "FoobarAB7_BazMoo_1DBAACCBDDDCBCDB-1",
                 "FoobarAB3_BazMoo_1DABABDBDCCDBCBA-1",


### PR DESCRIPTION
The PR addresses the ```not enough values to unpack (expected 3, got 1)``` error caused by headers being present when models were being created in transform(). The error was isolated to disordered MTX files. Transform() is expecting the pointer to be where the data starts. Instead, it received the header and not the gene-barcode-expression array. This was due to sort_mtx() not passing a file whose pointer was at the top to get_gene_expression_data(). To ensure the file pointer is always at the top of the file, get_gene_expression_data() [forces the pointer to the top of the file](https://github.com/broadinstitute/scp-ingest-pipeline/blob/7a1883a9b065fce6292a135c568047d4d0e1b4eb/ingest/expression_files/mtx.py#L195) with Python's [seek method](https://www.geeksforgeeks.org/python-seek-function/). 