### PR TITLE
Relax cell name validation for concurrent expression matrix parses (SCP-3009, SCP-3030)

### DIFF
--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -148,23 +148,17 @@ class GeneExpression:
         query_results: List[Dict] = GeneExpression.query_cells(
             study_id, client, additional_query_kwargs
         )
-        # The query did not return results
+
+        # there are no results so return an empty array
         if not query_results:
-            # check if the other expression matrices are "parsing", in which case ignore
-            for matrix_file_id in study_files_ids:
-                matrix_file = list(client['study_files'].find({"_id": matrix_file_id})).pop()
-                if matrix_file['parse_status'] == 'parsing':
-                    continue
-                else:
-                    raise ValueError(
-                        "There are study files that do not have cell names associated with them"
-                    )
-        # Flatten query results
-        existing_cells = [
-            values
-            for cell_values in query_results
-            for values in cell_values.get("values")
-        ]
+            existing_cells = []
+        else:
+            # Flatten query results
+            existing_cells = [
+                values
+                for cell_values in query_results
+                for values in cell_values.get("values")
+            ]
         return existing_cells
 
     @staticmethod
@@ -178,6 +172,9 @@ class GeneExpression:
             study_file_id (ObjectId): The file id the cell names belong to
             client: MongoDB client
         """
+        # raise error if there are no cell names present
+        if not cell_names:
+            raise ValueError("There were no cell names found in the header row of this matrix")
 
         existing_cells = GeneExpression.get_cell_names_from_study_file_id(
             study_id, study_file_id, client

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -150,9 +150,15 @@ class GeneExpression:
         )
         # The query did not return results
         if not query_results:
-            raise ValueError(
-                "There are study files that do not have cell names associated with them"
-            )
+            # check if the other expression matrices are "parsing", in which case ignore
+            for matrix_file_id in study_files_ids:
+                matrix_file = list(client['study_files'].find({"_id": matrix_file_id})).pop()
+                if matrix_file['parse_status'] == 'parsing':
+                    continue
+                else:
+                    raise ValueError(
+                        "There are study files that do not have cell names associated with them"
+                    )
         # Flatten query results
         existing_cells = [
             values

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -180,6 +180,16 @@ class TestExpressionFiles(unittest.TestCase):
                 )
             )
 
+        # ensure empty cell names throws error
+        with patch(
+                "expression_files.expression_files.GeneExpression.get_cell_names_from_study_file_id",
+                return_value=None,
+        ), self.assertRaises(ValueError) as em:
+            GeneExpression.check_unique_cells(
+                [], ObjectId(), ObjectId(), TestExpressionFiles.client_mock
+            )
+            self.assertEqual("There were no cell names found in the header row of this matrix", str(em.exception))
+
     @patch("expression_files.expression_files.GeneExpression.query_cells")
     def test_get_cell_names_from_study_file_id(self, mock_query_cells):
         with patch(
@@ -211,32 +221,10 @@ class TestExpressionFiles(unittest.TestCase):
 
             mock_query_cells.return_value = []
 
-            # mock another study file returning as "parsing"
-            client = MagicMock()
-            client['study_files'].find.return_value = [
-                {
-                    'parse_status': 'parsing'
-                }
-            ]
-
             cells = GeneExpression.get_cell_names_from_study_file_id(
-                ObjectId(), ObjectId(), client
+                ObjectId(), ObjectId(), MagicMock()
             )
             self.assertEqual(cells, [])
-
-            # mock another study_file returning as "parsed", but has no cells
-            client['study_files'].find.return_value = [
-                {
-                    'parse_status': 'parsed'
-                }
-            ]
-            self.assertRaises(
-                ValueError,
-                GeneExpression.get_cell_names_from_study_file_id,
-                ObjectId(),
-                ObjectId(),
-                client,
-            )
 
     def test_is_raw_count_file(self):
         client = MagicMock()

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -210,12 +210,32 @@ class TestExpressionFiles(unittest.TestCase):
             self.assertEqual(cells, expected)
 
             mock_query_cells.return_value = []
+
+            # mock another study file returning as "parsing"
+            client = MagicMock()
+            client['study_files'].find.return_value = [
+                {
+                    'parse_status': 'parsing'
+                }
+            ]
+
+            cells = GeneExpression.get_cell_names_from_study_file_id(
+                ObjectId(), ObjectId(), client
+            )
+            self.assertEqual(cells, [])
+
+            # mock another study_file returning as "parsed", but has no cells
+            client['study_files'].find.return_value = [
+                {
+                    'parse_status': 'parsed'
+                }
+            ]
             self.assertRaises(
                 ValueError,
                 GeneExpression.get_cell_names_from_study_file_id,
                 ObjectId(),
                 ObjectId(),
-                MagicMock(),
+                client,
             )
 
     def test_is_raw_count_file(self):


### PR DESCRIPTION
If a user uploads multiple expression matrices of the same "type" (e.g. raw/processed), there is currently a race condition with validating cell names that can cause both matrix files to fail ingest (although sometimes the second matrix will pass validation).  This is because `GeneExpression.get_cell_names_from_study_file_id` will see the presence of the other matrix files, but will not be able to find any cell name `DataArray` documents for these fails.  This throws a `ValueError` and fails the entire job.  The current workaround is to wait to upload the second matrix until the first has succeeded, but this is completely opaque to the end user.

This update removes that clause, and adds an upstream check to ensure that cells are parsed from any given matrix (a `ValueError` is raised if matrices don't have cell names: SCP-3030). When combined with work on SCP-2971 (which will stagger ingesting matrix files of the same type by waiting until the previous matrix has validated) this will allow users to upload 2+ matrix files of the same type concurrently.  End users should not notice any significant increase in parse times as validating and storing cell names is a relatively quick process, even for large matrix files.

This PR satisfies SCP-3009 and SCP-3030.