### PR TITLE
* SCP-3069 Store numeric arrays as group annotation types

### DIFF
--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -69,7 +69,7 @@ class CellMetadata(Annotations):
         for metadata_model in self.transform():
             yield metadata_model
 
-    def update_array_numeric_columns(self, annotation_name):
+    def update_numeric_array_columns(self, annotation_name):
         if not self.numeric_array_columns.values():
             self.numeric_array_columns[annotation_name] = True
 

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -111,7 +111,7 @@ class CellMetadata(Annotations):
         for annot_header in self.file.columns:
             annot_name = annot_header[0]
             annot_type = annot_header[1]
-            # When file is conventional and contain's numeric arrays
+            # When file is conventional and contains numeric arrays
             # the annotation type is changed to group for visualization purposes
             stored_mongo_annot_type: str = (
                 annot_type

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -12,6 +12,7 @@ import ntpath
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, Generator, List, Tuple, Union  # noqa: F401
+import copy
 
 from bson.objectid import ObjectId
 from mypy_extensions import TypedDict
@@ -134,7 +135,8 @@ class CellMetadata(Annotations):
             )
 
     def set_data_array(self, linear_data_id: str, annot_header: str):
-        data_array_attrs = locals()
+
+        data_array_attrs = copy.copy(locals())
         del data_array_attrs["annot_header"]
         del data_array_attrs["self"]
         annot_name = annot_header[0]

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -336,10 +336,7 @@ class IngestPipeline:
             IngestPipeline.dev_logger.info("Cell metadata file format valid")
             # Check file against metadata convention
             if validate_against_convention:
-                import copy
-
-                # A step in decoupling CellMetadata and IngestPipeline
-                if self.conforms_to_metadata_convention(copy.copy(self.cell_metadata)):
+                if self.conforms_to_metadata_convention(self.cell_metadata):
                     IngestPipeline.dev_logger.info(
                         "Cell metadata file conforms to metadata convention"
                     )

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -774,7 +774,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
     }
     if is_array_metadata(convention, metadatum):
         cast_values = []
-        metadata.add_update_annotation(metadatum)
+        metadata.update_numeric_array_columns(metadatum)
         try:
             # splitting on pipe character for array data, valid for Sarah's
             # programmatically generated SCP TSV metadata files. When ingesting

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -774,6 +774,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
     }
     if is_array_metadata(convention, metadatum):
         cast_values = []
+        metadata.add_update_annotation(metadatum)
         try:
             # splitting on pipe character for array data, valid for Sarah's
             # programmatically generated SCP TSV metadata files. When ingesting


### PR DESCRIPTION
Stored array-valued annotations that Mongo treated as “numeric” were plotted as NaN. To allow these annotations to be visualized in SCP, we should treat the array-based numeric data as a single string, and process the annotations as though they were regular group-based metadata entries (including storing all unique values).

From data file [valid_array_v2_1.2.txt](https://github.com/broadinstitute/scp-ingest-pipeline/blob/development/tests/data/valid_array_v2.1.2.txt), the numeric array model, 'disease__time_since_onset', will look as such:
```
{'name': 'disease__time_since_onset', 'annotation_type': 'group', 'values': [], 
'study_file_id': ObjectId('5dd5ae25421aa910a723a337'), 
'study_id': ObjectId('5d276a50421aa9117c982845')}
```

**Notice how the stored 'values', as in production, are treated as normal numeric annotations.**

Tests for the PR are captured in SCP-3082.

