### PR TITLE
* SCP-2909 Resolve "batch ops error" with retry using new random document ID

### DIFF
--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -182,13 +182,16 @@ class TestExpressionFiles(unittest.TestCase):
 
         # ensure empty cell names throws error
         with patch(
-                "expression_files.expression_files.GeneExpression.get_cell_names_from_study_file_id",
-                return_value=None,
+            "expression_files.expression_files.GeneExpression.get_cell_names_from_study_file_id",
+            return_value=None,
         ), self.assertRaises(ValueError) as em:
             GeneExpression.check_unique_cells(
                 [], ObjectId(), ObjectId(), TestExpressionFiles.client_mock
             )
-            self.assertEqual("There were no cell names found in the header row of this matrix", str(em.exception))
+            self.assertEqual(
+                "There were no cell names found in the header row of this matrix",
+                str(em.exception),
+            )
 
     @patch("expression_files.expression_files.GeneExpression.query_cells")
     def test_get_cell_names_from_study_file_id(self, mock_query_cells):
@@ -388,7 +391,9 @@ class TestExpressionFiles(unittest.TestCase):
         client_mock.reset_mock()
 
         def raiseError(*args, **kwargs):
-            raise BulkWriteError({"details": "foo"})
+            details = {"writeErrors": {"code": 2345}}
+
+            raise BulkWriteError(details)
 
         # Test exponential back off for BulkWriteError
         client_mock["collection"].insert_many.side_effect = raiseError

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -391,7 +391,7 @@ class TestExpressionFiles(unittest.TestCase):
         client_mock.reset_mock()
 
         def raiseError(*args, **kwargs):
-            details = {"writeErrors": {"code": 2345}}
+            details = {"writeErrors": [{"code": 2345}]}
 
             raise BulkWriteError(details)
 


### PR DESCRIPTION
This PR attempts to resolve the batch-ops error due to duplicate IDs by assigning another random ID and trying to re-insert. 

To test:
Find a file that already present in your Mongo instance.
On local instance of scp-ingest-pipeline try and ingest the same file with the same study and study file ID.
In ingest_files add ```self._id = < _id value in document you're truing to duplicate>```
In logs, you'll see that the batch ops error occurred. However, you'll see in Mongo the inserted document has a different id. 