### PR TITLE
Relocate IngestPipeline method about metadata convention to CellMetadata Class (SCP-3632)

### DIFF
--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -4,6 +4,6 @@ from .cell_metadata import CellMetadata
 from .validation.validate_metadata import *
 from .mongo_connection import MongoConnection
 from .monitoring.mixpanel_log import custom_metric
-from .config import init
+from . import config
 from .monitoring.metrics_service import MetricsService
 from .monitor import testing_guard, setup_logger

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -123,7 +123,8 @@ class CellMetadata(Annotations):
             self.kwargs["validate_convention"] is not None
             and self.kwargs["validate_convention"]
         ):
-            if self.kwargs["bq_dataset"] and self.kwargs["bq_table"]:
+            import_to_bq = self.kwargs["bq_dataset"] and self.kwargs["bq_table"]
+            validate_input_metadata(self, convention, bq_json=import_to_bq)
                 validate_input_metadata(self, convention, bq_json=True)
             else:
                 validate_input_metadata(self, convention)

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -119,15 +119,9 @@ class CellMetadata(Annotations):
         convention_file_object = IngestFiles(self.JSON_CONVENTION, ["application/json"])
         json_file = convention_file_object.open_file(self.JSON_CONVENTION)
         convention = json.load(json_file)
-        if (
-            self.kwargs["validate_convention"] is not None
-            and self.kwargs["validate_convention"]
-        ):
-            import_to_bq = self.kwargs["bq_dataset"] and self.kwargs["bq_table"]
-            validate_input_metadata(self, convention, bq_json=import_to_bq)
-                validate_input_metadata(self, convention, bq_json=True)
-            else:
-                validate_input_metadata(self, convention)
+
+        import_to_bq = self.kwargs["bq_dataset"] and self.kwargs["bq_table"]
+        validate_input_metadata(self, convention, bq_json=import_to_bq)
 
         json_file.close()
         return not report_issues(self)

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, Generator, List, Tuple, Union  # noqa: F401
 import copy
+import json
 
 from bson.objectid import ObjectId
 from mypy_extensions import TypedDict
@@ -20,16 +21,25 @@ from mypy_extensions import TypedDict
 try:
     # Used when importing internally and in tests
     from annotations import Annotations
-    from ingest_files import DataArray
+    from ingest_files import DataArray, IngestFiles
+    from validation.validate_metadata import (
+        report_issues,
+        validate_input_metadata,
+        write_metadata_to_bq,
+    )
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .annotations import Annotations
-    from .ingest_files import DataArray
+    from .ingest_files import DataArray, IngestFiles
 
 
 class CellMetadata(Annotations):
     ALLOWED_FILE_TYPES = ["text/csv", "text/plain", "text/tab-separated-values"]
     COLLECTION_NAME = "cell_metadata"
+    # File location for metadata json convention
+    JSON_CONVENTION = (
+        "../schema/alexandria_convention/alexandria_convention_schema.json"
+    )
 
     def __init__(
         self,
@@ -51,6 +61,7 @@ class CellMetadata(Annotations):
         self.ontology_label = dict()
         self.cells = []
         self.numeric_array_columns = {}
+        self.kwargs = kwargs
 
     # This model pertains to columns from cell metadata files
     @dataclass
@@ -102,6 +113,23 @@ class CellMetadata(Annotations):
             msg = "Header names can not be coordinate values x, y, or z (case insensitive)"
             self.store_validation_issue("error", "format", msg)
             return False
+
+    def conforms_to_metadata_convention(self):
+        """ Determines if cell metadata file follows metadata convention"""
+        convention_file_object = IngestFiles(self.JSON_CONVENTION, ["application/json"])
+        json_file = convention_file_object.open_file(self.JSON_CONVENTION)
+        convention = json.load(json_file)
+        if (
+            self.kwargs["validate_convention"] is not None
+            and self.kwargs["validate_convention"]
+        ):
+            if self.kwargs["bq_dataset"] and self.kwargs["bq_table"]:
+                validate_input_metadata(self, convention, bq_json=True)
+            else:
+                validate_input_metadata(self, convention)
+
+        json_file.close()
+        return not report_issues(self)
 
     def transform(self):
         """ Builds cell metadata model"""

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -31,7 +31,7 @@ except ImportError:
     from .expression_files import GeneExpression
     from ..ingest_files import IngestFiles
     from ..monitoring.mixpanel_log import custom_metric
-    from ..config import config
+    from .. import config
 
 
 class MTXIngestor(GeneExpression, IngestFiles):

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -76,7 +76,7 @@ try:
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .ingest_files import IngestFiles
-    from .config import config
+    from . import config
     from .monitoring.metrics_service import MetricsService
     from .subsample import SubSample
     from .monitoring.mixpanel_log import custom_metric

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -46,11 +46,9 @@ from google.cloud import bigquery
 sys.path.append("..")
 try:
     # Used when importing internally and in tests
-    from cell_metadata import CellMetadata
     from monitor import setup_logger
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
-    from ..cell_metadata import CellMetadata
     from ..monitor import setup_logger
 
 
@@ -154,7 +152,9 @@ class OntologyRetriever:
     cached_ontologies = {}
     cached_terms = {}
 
-    def retrieve_ontology_term_label_and_synonyms(self, term, property_name, convention, attribute_type: str):
+    def retrieve_ontology_term_label_and_synonyms(
+        self, term, property_name, convention, attribute_type: str
+    ):
         """Retrieve an individual term label and any synonymns from an ontology
         returns JSON payload of ontology, or None if unsuccessful
         Will store any retrieved labels/synonyms for faster validation of downstream terms
@@ -195,7 +195,9 @@ class OntologyRetriever:
         if property_name == "organ_region":
             return self.retrieve_mouse_brain_term(term, property_name)
         else:
-            return self.retrieve_ols_term(ontology_urls, term, property_name, attribute_type)
+            return self.retrieve_ols_term(
+                ontology_urls, term, property_name, attribute_type
+            )
 
     # Attach exponential backoff to external HTTP requests
     @backoff.on_exception(
@@ -271,7 +273,9 @@ class OntologyRetriever:
                 if term_json['synonyms']:
                     synonyms += term_json['synonyms']
                 # safe lookup of nested dictionary
-                related_synonyms = term_json.get('annotation', {}).get('has_related_synonym')
+                related_synonyms = term_json.get('annotation', {}).get(
+                    'has_related_synonym'
+                )
                 if related_synonyms:
                     synonyms += related_synonyms
                 # uniquify list via set and return
@@ -318,6 +322,7 @@ class OntologyRetriever:
                 "allen_mouse_brain_atlas"
             ] = fetch_allen_mouse_brain_atlas_remote()
         return self.cached_ontologies["allen_mouse_brain_atlas"]
+
 
 def parse_organ_region_ontology_id(term):
     """Extract term id from valid identifiers or raise a ValueError
@@ -1044,6 +1049,7 @@ def exit_if_errors(metadata):
         exit(1)
     return errors
 
+
 def is_label_or_synonym(labels, provided_label):
     """Determine if a user-provided ontology label is a valid label or synonymn
     :param labels: cached ontology label/synonyms from retriever.retrieve_ontology_term_label_and_synonyms
@@ -1061,6 +1067,7 @@ def is_label_or_synonym(labels, provided_label):
             return False
     else:
         return False
+
 
 def validate_collected_ontology_data(metadata, convention):
     """Evaluate collected ontology_id, ontology_label info in

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="scp-ingest-pipeline",
-    version="1.11.0",
+    version="1.11.1",
     description="ETL pipeline for single-cell RNA-seq data",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="scp-ingest-pipeline",
-    version="1.11.1",
+    version="1.12.1",
     description="ETL pipeline for single-cell RNA-seq data",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_cell_metadata.py
+++ b/tests/test_cell_metadata.py
@@ -95,9 +95,9 @@ class TestCellMetadata(unittest.TestCase):
         )
         cm.preprocess(is_metadata_convention=True)
         convention_file_object = IngestFiles(
-            IngestPipeline.JSON_CONVENTION, ["application/json"]
+            CellMetadata.JSON_CONVENTION, ["application/json"]
         )
-        json_file = convention_file_object.open_file(IngestPipeline.JSON_CONVENTION)
+        json_file = convention_file_object.open_file(CellMetadata.JSON_CONVENTION)
         convention = json.load(json_file)
         collect_jsonschema_errors(cm, convention)
         for metadata_model in cm.transform():

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -27,19 +27,19 @@ import numpy as np
 sys.path.append("../ingest")
 sys.path.append("../ingest/validation")
 
+from cell_metadata import CellMetadata
 from validate_metadata import (
     create_parser,
     report_issues,
     collect_jsonschema_errors,
     validate_schema,
-    CellMetadata,
     validate_collected_ontology_data,
     collect_cell_for_ontology,
     validate_input_metadata,
     request_json_with_backoff,
     MAX_HTTP_ATTEMPTS,
     is_empty_string,
-    is_label_or_synonym
+    is_label_or_synonym,
 )
 
 
@@ -715,7 +715,10 @@ class TestValidateMetadata(unittest.TestCase):
 
     def test_is_label_or_synonym(self):
         label = "10x 3' v2"
-        possible_matches = {"label": "10x 3' v2", "synonyms": ["10X 3' v2", "10x 3' v2 sequencing"]}
+        possible_matches = {
+            "label": "10x 3' v2",
+            "synonyms": ["10X 3' v2", "10x 3' v2 sequencing"],
+        }
         self.assertTrue(is_label_or_synonym(possible_matches, label))
         label = "10X 3' v2"
         self.assertTrue(is_label_or_synonym(possible_matches, label))
@@ -738,6 +741,7 @@ class TestValidateMetadata(unittest.TestCase):
             report_issues(metadata), "Valid ontology content should not elicit error"
         )
         self.teardown_metadata(metadata)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tests in single_cell_portal repo fail due to Classes in the repo that were refactored earlier this year. Methods used for tests in single_cell_portal are now obsolete. To use scp-ingest-pipeline as-is in the tests, an IngestPipeline object would need to be instantiated to use the conforms_to_metadata_convention method, which is more complex than instantiating a CellMetadata object which is what the current, broken tests do. Logically, conforms_to_metadata_convention should be a CellMetadata method because none of the other ingest file types require the metadata convention. To ease the repair of tests in the single_cell_portal repo, this PR moves the conforms_to_metadata_convention method to the Cell Metadata Class.

To test (is kinda finicky right now, sorry!)
pre-test: find a study in your dev instance and get a valid study_id and study_file_id
ensure your python environment is up to date with requirements.txt in scp-ingest-pipeline repo
(not sure if this works differently if your gcloud config is set to your service account or your Broad identity, I used my Broad identity)
Have your mondoDB credentials set up as environment variables (Let me know if this isn't documented already, I think Eno made a doc somewhere. I have a script that set's it up for me using vault commands)

Run the following 
python ingest_pipeline.py --study-id <your study_id> --study-file-id <your  study-file-id> ingest_cell_metadata --cell-metadata-file <path/to/repo>/scp-ingest-pipeline/tests/data/annotation/metadata/convention/valid_array_v2.1.2.txt --study-accession <your study accession> --ingest-cell-metadata --validate-convention

Expect [many warning messages](https://docs.google.com/document/d/1baT6Rn1TNwccele56vIstvTjHnRgacbTkmMCPF5CIBI/edit#heading=h.fk1rtq1m2hm) but no errors.

This work supports SCP-3631 and corrects the import errors that blocked SCP-3414.