### PR TITLE
Restore storage of numeric array-based metadata annotation values (SCP-3899)

### DIFF
--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -142,7 +142,11 @@ class CellMetadata(Annotations):
                 else "group"
             )
 
-            group = True if annot_type == "group" else False
+            group = (
+                True
+                if (annot_type == "group" or stored_mongo_annot_type == "group")
+                else False
+            )
             # should not store annotations with >200 unique values for viz
             # annot_header is the column of data, which includes name and type
             # large is any annotation with more than 200 + 2 unique values

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from typing import Dict, Generator, List, Tuple, Union  # noqa: F401
 import copy
 import json
-import logging
 
 from bson.objectid import ObjectId
 from mypy_extensions import TypedDict
@@ -28,18 +27,10 @@ try:
         validate_input_metadata,
         write_metadata_to_bq,
     )
-    from monitor import setup_logger
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
     from .annotations import Annotations
     from .ingest_files import DataArray, IngestFiles
-    from ..monitor import setup_logger
-
-dev_logger = setup_logger(__name__, "log.txt", format="support_configs")
-
-user_logger = setup_logger(
-    __name__ + ".user_logger", "user_log.txt", level=logging.ERROR
-)
 
 
 class CellMetadata(Annotations):

--- a/tests/mock_data/annotation/metadata/convention/valid_array_v2_1_2.py
+++ b/tests/mock_data/annotation/metadata/convention/valid_array_v2_1_2.py
@@ -12,7 +12,7 @@ valid_array_v2_1_2_models = {
         "disease__time_since_onset": {
             "name": "disease__time_since_onset",
             "annotation_type": "group",
-            "values": [],
+            "values": ['12|2', '1', '24|2', '36|3|1', '0'],
             "study_file_id": ObjectId("600f42bdb067340e777b1385"),
             "study_id": ObjectId("5ea08bb17b2f150f29f4d952"),
         },


### PR DESCRIPTION
For visualization, numeric array-based metadata annotation values are treated as group-based values because they are string representing a series of values and not truly a numeric array. (Example: in our test file `valid_array_v2.1.2.txt`, values for disease__time_since_onset look like: '12|2', '1', '24|2', '36|3|1', '0')

Previous work, per mock data for `test_transfrom` in test_cell_metadata.py had erroneously assumed the values would not be stored. This PR restores the storage of numeric array-based metadata annotation values so they can be used in visualization.

To test: 
- set your local instance "Ingest Pipeline Docker Image" configuration to use:
gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_fix_string2float:af281d0
- upload the metadata file found at:
https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/development/tests/data/annotation/metadata/convention/valid_array_v2.1.2.txt
- in the Single Cell Portal Notifier email for the metadata file, you should see
`disease__time_since_onset: group (12|2, 1, 24|2, 36|3|1, 0)`
and not a bare entry with  no values:
`disease__time_since_onset: group`

This PR supports SCP-3899
