### PR TITLE
Log ingest annotation validation errors to Mixpanel (SCP-3921)

### DIFF
--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -212,7 +212,7 @@ class Annotations(IngestFiles):
         self, type, category, msg, issue_name=None, associated_info=None
     ):
         """Stores validation issues in proper arrangement
-            :param type: type of issue (error or warn)
+            :param type: type of issue (error or warning)
         :param category: issue category (format, jsonschema, ontology)
         :param msg: issue message
         :param value: list of IDs associated with the issue

--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -46,7 +46,12 @@ class Annotations(IngestFiles):
         # lambda below initializes new key with nested dictionary as value and avoids KeyError
         self.issues = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         # collect error info for Mixpanel reporting
-        self.props = {"errorTypes": [], "errors": [], "warnTypes": [], "warnings": []}
+        self.props = {
+            "errorTypes": [],
+            "errors": [],
+            "warningTypes": [],
+            "warnings": [],
+        }
         csv_file, self.file_handle = self.open_file(self.file_path)
         # Remove white spaces, quotes (only lowercase annot_types)
         self.headers = [header.strip().strip('"') for header in next(csv_file)]
@@ -223,8 +228,8 @@ class Annotations(IngestFiles):
             if msg not in self.props["errors"]:
                 self.props["errors"].append(msg)
         elif type == "warn" and issue_name:
-            if issue_name not in self.props["warnTypes"]:
-                self.props["warnTypes"].append(issue_name)
+            if issue_name not in self.props["warningTypes"]:
+                self.props["warningTypes"].append(issue_name)
             if msg not in self.props["warnings"]:
                 self.props["warnings"].append(msg)
 

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -111,7 +111,7 @@ class CellMetadata(Annotations):
         else:
             msg = "Header names can not be coordinate values x, y, or z (case insensitive)"
             self.store_validation_issue(
-                "error", "format", msg, issue_name="format:cap:metadata-no-coordinates"
+                "error", msg, "format:cap:metadata-no-coordinates"
             )
             return False
 

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -55,8 +55,6 @@ class CellMetadata(Annotations):
             self, file_path, self.ALLOWED_FILE_TYPES, study_id, study_file_id
         )
         self.cell_names = []
-        # lambda below initializes new key with nested dictionary as value and avoids KeyError
-        self.issues = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         self.ontology = defaultdict(lambda: defaultdict(list))
         self.ordered_ontology = defaultdict(list)
         self.ordered_labels = defaultdict(list)

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -110,7 +110,9 @@ class CellMetadata(Annotations):
             return True
         else:
             msg = "Header names can not be coordinate values x, y, or z (case insensitive)"
-            self.store_validation_issue("error", "format", msg)
+            self.store_validation_issue(
+                "error", "format", msg, issue_name="format:cap:metadata-no-coordinates"
+            )
             return False
 
     def conforms_to_metadata_convention(self):

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -94,10 +94,7 @@ class Clusters(Annotations):
                     is_valid = False
                     msg = f"Missing coordinate values in {annot_name} column"
                     self.store_validation_issue(
-                        "error",
-                        "format",
-                        msg,
-                        issue_name="content:cluster:missing-coordinates-values",
+                        "error", msg, "content:cluster:missing-coordinates-values"
                     )
         return is_valid
 
@@ -118,7 +115,7 @@ class Clusters(Annotations):
                     "Header must have coordinate values 'x' and 'y' (case insensitive)"
                 )
                 self.store_validation_issue(
-                    "error", "format", msg, issue_name="format:cap:cluster-coordinates"
+                    "error", msg, "format:cap:cluster-coordinates"
                 )
                 return False
         return True

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -93,7 +93,12 @@ class Clusters(Annotations):
                 if self.file[annot_name].isna().any().bool():
                     is_valid = False
                     msg = f"Missing coordinate values in {annot_name} column"
-                    self.store_validation_issue("error", "format", msg)
+                    self.store_validation_issue(
+                        "error",
+                        "format",
+                        msg,
+                        issue_name="content:cluster:missing-coordinates-values",
+                    )
         return is_valid
 
     def is_valid_format(self):
@@ -112,7 +117,9 @@ class Clusters(Annotations):
                 msg = (
                     "Header must have coordinate values 'x' and 'y' (case insensitive)"
                 )
-                self.store_validation_issue("error", "format", msg)
+                self.store_validation_issue(
+                    "error", "format", msg, issue_name="format:cap:cluster-coordinates"
+                )
                 return False
         return True
 

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -46,6 +46,7 @@ class MetricProperties:
             "fileName": study_file.file_name,
             "fileType": study_file.file_type,
             "fileSize": study_file.file_size,
+            "logger": "ingest-pipeline"
             "appId": "single-cell-portal",
         }
 

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -91,6 +91,9 @@ class Study:
             study_id = ObjectId(study_id)
         except Exception:
             raise ValueError("Must pass in valid object ID for study ID")
+        # ToDo: complete bypass of Mongo in developer mode
+        # until then, the bson check above is necessary
+        # set dummy accession if running in developer mode
         if bypass_mongo_input_validation():
             self.accession = "SCPdev"
         else:
@@ -124,10 +127,14 @@ class StudyFile:
             study_file_id = ObjectId(study_file_id)
         except Exception:
             raise ValueError("Must pass in valid object ID for study file ID")
+        # ToDo: complete bypass of Mongo in developer mode
+        # until then, the bson check above is necessary
+        # set dummy values if running in developer mode
         if bypass_mongo_input_validation():
             self.file_type = "input_validation_bypassed"
             self.file_size = 1
-            self.file_name = study_file_id
+            self.file_name = str(study_file_id)
+            self.trigger = 'upload'
         else:
             query = MONGO_CONNECTION._client["study_files"].find({"_id": study_file_id})
             query_results = list(query)
@@ -140,3 +147,7 @@ class StudyFile:
                 self.file_type = self.study_file["file_type"]
                 self.file_size = self.study_file["upload_file_size"]
                 self.file_name = self.study_file["name"]
+                if self.study_file.get("remote_location") is not None:
+                    self.trigger = 'sync'
+                else:
+                    self.trigger = 'upload'

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -47,6 +47,7 @@ class MetricProperties:
             "fileName": study_file.file_name,
             "fileType": study_file.file_type,
             "fileSize": study_file.file_size,
+            "trigger": study_file.trigger,
             "logger": "ingest-pipeline",
             "appId": "single-cell-portal",
         }
@@ -132,7 +133,7 @@ class StudyFile:
             self.file_type = "input_validation_bypassed"
             self.file_size = 1
             self.file_name = str(study_file_id)
-            self.trigger = 'upload'
+            self.trigger = 'dev_mode'
         else:
             query = MONGO_CONNECTION._client["study_files"].find({"_id": study_file_id})
             query_results = list(query)

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -46,7 +46,7 @@ class MetricProperties:
             "fileName": study_file.file_name,
             "fileType": study_file.file_type,
             "fileSize": study_file.file_size,
-            "logger": "ingest-pipeline"
+            "logger": "ingest-pipeline",
             "appId": "single-cell-portal",
         }
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -454,7 +454,7 @@ def push_mixpanel_props(props):
 def set_mixpanel_nums(props):
     """
     """
-    for prop in ["errorTypes", "errors", "warnTypes", "warnings"]:
+    for prop in ["errorTypes", "errors", "warningTypes", "warnings"]:
         num_prop = "num" + prop.capitalize()
         if props.get(prop):
             props[num_prop] = len(props[prop])

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -579,7 +579,7 @@ def main() -> None:
     MetricsService.log(config.get_parent_event_name(), config.get_metric_properties())
     MetricsService.log("file-validation", config.get_metric_properties())
 
-    # If in developer mode, area to print metrics info for troubleshooting
+    # If in developer mode, print metrics properties
     if config.bypass_mongo_writes():
         metrics_dump = config.get_metric_properties().get_properties()
         for key in metrics_dump.keys():

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -8,7 +8,7 @@ a remote MongoDB instance.
 PREREQUISITES
 See https://github.com/broadinstitute/scp-ingest-pipeline#prerequisites
 
-DEVELOPER SETUP (see also ../scripts/setup_mongo_dev)
+DEVELOPER SETUP (see also ../scripts/setup_mongo_dev.sh)
 To run ingest_pipeline on the command line, set the following environment variable(s):
 Set up access to your developer MongoDB instance
     export MONGODB_USERNAME='single_cell'

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -513,6 +513,7 @@ def main() -> None:
     status, status_cell_metadata = run_ingest(ingest, arguments, parsed_args)
     # Log Mixpanel events
     MetricsService.log(config.get_parent_event_name(), config.get_metric_properties())
+    MetricsService.log("file-validation", config.get_metric_properties())
     # Exit pipeline
     exit_pipeline(ingest, status, status_cell_metadata, arguments)
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -458,8 +458,6 @@ def set_mixpanel_nums(props):
         num_prop = "num" + prop.capitalize()
         if props.get(prop):
             props[num_prop] = len(props[prop])
-        else:
-            props[num_prop] = 0
     return props
 
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -8,7 +8,7 @@ a remote MongoDB instance.
 PREREQUISITES
 See https://github.com/broadinstitute/scp-ingest-pipeline#prerequisites
 
-DEVELOPER SETUP
+DEVELOPER SETUP (see also ../scripts/setup_mongo_dev)
 To run ingest_pipeline on the command line, set the following environment variable(s):
 Set up access to your developer MongoDB instance
     export MONGODB_USERNAME='single_cell'

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -8,6 +8,20 @@ a remote MongoDB instance.
 PREREQUISITES
 See https://github.com/broadinstitute/scp-ingest-pipeline#prerequisites
 
+DEVELOPER SETUP
+To run ingest_pipeline on the command line, set the following environment variable(s):
+Set up access to your developer MongoDB instance
+    export MONGODB_USERNAME='single_cell'
+    export DATABASE_NAME='single_cell_portal_development'
+leverage Vault to securely set up the following environment variable(s):
+    MONGODB_PASSWORD
+    DATABASE_HOST
+Bypass MongoDB check for ingest file info in MongoDB
+(wishlist - modify ingest to bypass using remote Mongo instance in developer mode)
+    export BYPASS_MONGO_INPUT_VALIDATION='yes'
+(optional) To have validation events report to Mixpanel, set:
+    export BARD_HOST_URL="https://terra-bard-dev.appspot.com"
+
 EXAMPLES
 # Takes expression file and stores it into MongoDB
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -327,6 +327,7 @@ class IngestPipeline:
                     )
                     pass
                 else:
+                    report_cell_metadata_props(self.cell_metadata)
                     return 1
 
             for metadata_model in self.cell_metadata.execute_ingest():
@@ -347,9 +348,7 @@ class IngestPipeline:
             return status if status is not None else 1
         else:
             report_issues(self.cell_metadata)
-            self.cell_metadata.props = set_mixpanel_nums(self.cell_metadata.props)
-            metrics_dump = config.get_metric_properties().get_properties()
-            metrics_dump.update(self.cell_metadata.props)
+            report_cell_metadata_props(self.cell_metadata)
             IngestPipeline.user_logger.error("Cell metadata file format invalid")
             return 1
 
@@ -420,6 +419,15 @@ class IngestPipeline:
                 log_exception(IngestPipeline.dev_logger, IngestPipeline.user_logger, e)
                 return 1
         return 0
+
+
+def report_cell_metadata_props(cell_metadata):
+    """Push validation issues from cell_metadata object to
+        metric_properties for Mixpanel logging
+    """
+    cell_metadata.props = set_mixpanel_nums(cell_metadata.props)
+    metrics_dump = config.get_metric_properties().get_properties()
+    metrics_dump.update(cell_metadata.props)
 
 
 def set_mixpanel_nums(props):

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -419,7 +419,7 @@ def validate_schema(json, metadata):
     except jsonschema.SchemaError:
         error_msg = "Invalid metadata convention file, cannot validate metadata."
         metadata.store_validation_issue(
-            "error", error_msg, "runtime:invalid_convention", issue_type="runtime",
+            "error", error_msg, "runtime:invalid_convention", issue_type="runtime"
         )
         return None
 
@@ -540,7 +540,10 @@ def insert_array_ontology_label_row_data(
                     f'"{id}" - using "{label_lookup}" per {reference_ontology}'
                 )
                 metadata.store_validation_issue(
-                    "warn", error_msg, "ontology:missing-label-lookup", associated_info=[cell_id]
+                    "warn",
+                    error_msg,
+                    "ontology:missing-label-lookup",
+                    associated_info=[cell_id],
                 )
             except BaseException as e:
                 print(e)
@@ -593,13 +596,19 @@ def insert_ontology_label_row_data(
                 f'"{id}" - using "{label}" per {reference_ontology}'
             )
             metadata.store_validation_issue(
-                "warn", error_msg, "ontology:missing-label-lookup", associated_info=[cell_id]
+                "warn",
+                error_msg,
+                "ontology:missing-label-lookup",
+                associated_info=[cell_id],
             )
         except BaseException as e:
             print(e)
             error_msg = f"Optional column {ontology_label} empty and could not be resolved from {property_name} column value {row[property_name]}"
             metadata.store_validation_issue(
-                "warn", error_msg, "ontology:label-lookup-error", associated_info=[cell_id]
+                "warn",
+                error_msg,
+                "ontology:label-lookup-error",
+                associated_info=[cell_id],
             )
     else:
         metadata.ordered_ontology[property_name].append(id)
@@ -743,9 +752,7 @@ def compare_type_annots_to_convention(metadata, convention):
                     f'Convention expects "{expected}" values.'
                 )
                 metadata.store_validation_issue(
-                    "error",
-                    error_msg,
-                    "content:invalid-type:value-type-mismatch",
+                    "error", error_msg, "content:invalid-type:value-type-mismatch"
                 )
         except TypeError:
             for k, v in annot_equivalents.items():
@@ -762,17 +769,13 @@ def compare_type_annots_to_convention(metadata, convention):
                     f"{metadatum}: missing TYPE annotation in metadata file. "
                     f'Convention expects "{expected}" annotation.'
                 )
-                metadata.store_validation_issue(
-                    "error", error_msg, "format:cap:type"
-                )
+                metadata.store_validation_issue("error", error_msg, "format:cap:type")
             else:
                 error_msg = (
                     f'{metadatum}: invalid "{annot}" annotation in metadata file. '
                     f'Convention expects "{expected}" annotation.'
                 )
-                metadata.store_validation_issue(
-                    "error", error_msg, "format:cap:type"
-                )
+                metadata.store_validation_issue("error", error_msg, "format:cap:type")
 
 
 def cast_boolean_type(value):
@@ -868,7 +871,10 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
                     "If multiple values are expected, use a pipe ('|') to separate values."
                 )
                 metadata.store_validation_issue(
-                    "warn", msg, "content:array-no-pipes", associated_info=[id_for_error_detail]
+                    "warn",
+                    msg,
+                    "content:array-no-pipes",
+                    associated_info=[id_for_error_detail],
                 )
 
             # splitting on pipe character for array data, valid for Sarah's
@@ -1228,10 +1234,7 @@ def validate_collected_ontology_data(metadata, convention):
                 error_msg = f"External service outage connecting to {ontology_urls} when querying {ontology_id}:{ontology_label}: {err}"
                 dev_logger.exception(error_msg)
                 metadata.store_validation_issue(
-                    "error",
-                    error_msg,
-                    "runtime:server-error"
-                    issue_type="runtime",
+                    "error", error_msg, "runtime:server-error", issue_type="runtime"
                 ),
                 # immediately return as validation cannot continue
                 return
@@ -1308,9 +1311,7 @@ def review_metadata_names(metadata):
                 f"allowed in metadata name"
             )
             metadata.store_validation_issue(
-                "error",
-                error_msg,
-                "format:cap:only-alphanumeric-underscore",
+                "error", error_msg, "format:cap:only-alphanumeric-underscore"
             )
 
 
@@ -1407,16 +1408,12 @@ def detect_excel_drag(metadata, convention):
                         if multiply_assigned:
                             msg += f"Check for mismatches between ontology ID and provided ontology label(s) {multiply_assigned}\n"
                     metadata.store_validation_issue(
-                        "error",
-                        msg,
-                        "ontology:multiply-assigned-label",
+                        "error", msg, "ontology:multiply-assigned-label"
                     )
                     dev_logger.exception(msg)
             except ValueError as valueError:
                 metadata.store_validation_issue(
-                    "error",
-                    associated_info=valueError.args[0],
-                    "ontology:label-lookup-error",
+                    "error", valueError.args[0], "ontology:label-lookup-error"
                 )
 
     return excel_drag

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -499,7 +499,7 @@ def validate_cells_unique(metadata):
             "format",
             error_msg,
             associated_info=dups,
-            issue_name="duplicate:cells-within-file",
+            issue_name="content:duplicate:cells-within-file",
         )
     return valid
 
@@ -516,7 +516,7 @@ def insert_array_ontology_label_row_data(
             "ontology",
             error_msg,
             associated_info=[cell_id],
-            issue_name="content:metadata:ontology-array-length-mismatch",
+            issue_name="ontology:array-length-mismatch",
         )
         return row
 
@@ -556,7 +556,7 @@ def insert_array_ontology_label_row_data(
                     "ontology",
                     error_msg,
                     associated_info=[cell_id],
-                    issue_name="content:metadata:ontology-label-lookup",
+                    issue_name="ontology:label-lookup-error",
                 )
             array_label_for_bq.append(label_lookup)
         row[ontology_label] = array_label_for_bq
@@ -672,7 +672,7 @@ def collect_cell_for_ontology(
             "ontology",
             missing_column_message,
             associated_info=[cell_id],
-            issue_name="content:metadata:missing-required-values",
+            issue_name="content:missing-required-values",
         )
 
         # metadata.ontology[property_name][(updated_row[property_name], None)].append(cell_id)
@@ -750,7 +750,7 @@ def compare_type_annots_to_convention(metadata, convention):
                     "error",
                     "type",
                     error_msg,
-                    issue_name="content:metadata:value-type-mismatch",
+                    issue_name="content:invalid-type:value-type-mismatch",
                 )
         except TypeError:
             for k, v in annot_equivalents.items():
@@ -903,7 +903,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
                 "type",
                 error_msg,
                 associated_info=[id_for_error_detail],
-                issue_name="content:metadata:value-type-mismatch",
+                issue_name="content:invalid-type:value-type-mismatch",
             )
         # This exception should only trigger if a single-value boolean array
         # metadata is being cast - the value needs to be passed as an array,
@@ -939,7 +939,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
                 "type",
                 error_msg,
                 associated_info=[id_for_error_detail],
-                issue_name="content:metadata:value-type-mismatch",
+                issue_name="content:invalid-type:value-type-mismatch",
             )
         # particular metadatum is not in convention, metadata does not need
         # to be added to new_row for validation, return empty dictionary
@@ -1006,7 +1006,7 @@ def process_metadata_row(metadata, convention, line):
                             "ontology",
                             msg,
                             associated_info=row_info["CellID"],
-                            issue_name="content:metadata:missing-required-values",
+                            issue_name="content:missing-required-values",
                         )
                         dev_logger.error(msg)
 
@@ -1211,7 +1211,7 @@ def validate_collected_ontology_data(metadata, convention):
                             associated_info=metadata.ontology[property_name][
                                 (ontology_id, ontology_label)
                             ],
-                            issue_name="content:metadata:missing-required-values",
+                            issue_name="content:missing-required-values",
                         )
                     else:
                         error_msg = (
@@ -1225,7 +1225,7 @@ def validate_collected_ontology_data(metadata, convention):
                             associated_info=metadata.ontology[property_name][
                                 (ontology_id, ontology_label)
                             ],
-                            issue_name="content:metadata:label-not-match-id",
+                            issue_name="ontology:label-not-match-id",
                         )
             except ValueError as valueError:
                 metadata.store_validation_issue(
@@ -1235,7 +1235,7 @@ def validate_collected_ontology_data(metadata, convention):
                     associated_info=metadata.ontology[property_name][
                         (ontology_id, ontology_label)
                     ],
-                    issue_name="content:metadata:ontology-label-lookup",
+                    issue_name="ontology:label-lookup-error",
                 )
             except requests.exceptions.RequestException as err:
                 error_msg = f"External service outage connecting to {ontology_urls} when querying {ontology_id}:{ontology_label}: {err}"
@@ -1266,10 +1266,7 @@ def confirm_uniform_units(metadata, convention):
                     f"{name}: values for each unit metadata required to be uniform"
                 )
                 metadata.store_validation_issue(
-                    "error",
-                    "convention",
-                    error_msg,
-                    issue_name="content:metadata:uniform-units",
+                    "error", "convention", error_msg, issue_name="content:uniform-units"
                 )
 
 
@@ -1427,7 +1424,7 @@ def detect_excel_drag(metadata, convention):
                         "error",
                         "ontology",
                         msg,
-                        issue_name="content:metadata:mismatched-id-label",
+                        issue_name="ontology:multiply-assigned-label",
                     )
                     dev_logger.exception(msg)
             except ValueError as valueError:
@@ -1435,7 +1432,7 @@ def detect_excel_drag(metadata, convention):
                     "error",
                     "ontology",
                     associated_info=valueError.args[0],
-                    issue_name="content:metadata:ontology-label-lookup",
+                    issue_name="ontology:label-lookup-error",
                 )
 
     return excel_drag

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -1061,8 +1061,14 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
                 line = next(rows)
             except StopIteration:
                 break
-        # if js_errors:
-        metadata.issues["error"]["convention"] = js_errors
+        if js_errors:
+            metadata.store_validation_issue(
+                "error",
+                "convention",
+                "One or more errors from jsonschema validation of metadata content against Alexandria Convention detected",
+                issue_name="content:schema-error",
+            )
+            metadata.issues["error"]["convention"] = js_errors
         validate_cells_unique(metadata)
     else:
         return False

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -1234,7 +1234,10 @@ def validate_collected_ontology_data(metadata, convention):
                 error_msg = f"External service outage connecting to {ontology_urls} when querying {ontology_id}:{ontology_label}: {err}"
                 dev_logger.exception(error_msg)
                 metadata.store_validation_issue(
-                    "error", error_msg, "runtime:server-error", issue_type="runtime"
+                    "error",
+                    error_msg,
+                    "runtime:request-exception",
+                    issue_type="runtime",
                 ),
                 # immediately return as validation cannot continue
                 return

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -1061,8 +1061,8 @@ def collect_jsonschema_errors(metadata, convention, bq_json=None):
         if js_errors:
             metadata.store_validation_issue(
                 "error",
-                "One or more errors from jsonschema validation of metadata content against Alexandria Convention detected",
-                "jsonschema:schema-error",
+                "One or more errors detected validating metadata content against metadata convention",
+                "convention:jsonschema-error",
             )
             metadata.issues["error"]["convention"] = js_errors
         validate_cells_unique(metadata)

--- a/scripts/setup_mongo_dev
+++ b/scripts/setup_mongo_dev
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export MONGODB_USERNAME='single_cell'
+export DATABASE_NAME='single_cell_portal_development'
+vault login -method=github token=`~/bin/git-vault-token`
+export MONGODB_PASSWORD=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/user | grep password | awk '{ print $2 }' `
+export DATABASE_HOST=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/hostname | grep ip | awk '{ $2=substr($2,2,length($2)-2); print $2 }' ` 
+export BYPASS_MONGO_WRITES='yes'
+export BARD_HOST_URL="https://terra-bard-dev.appspot.com"

--- a/scripts/setup_mongo_dev
+++ b/scripts/setup_mongo_dev
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-export MONGODB_USERNAME='single_cell'
-export DATABASE_NAME='single_cell_portal_development'
-vault login -method=github token=`~/bin/git-vault-token`
-export MONGODB_PASSWORD=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/user | grep password | awk '{ print $2 }' `
-export DATABASE_HOST=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/hostname | grep ip | awk '{ $2=substr($2,2,length($2)-2); print $2 }' ` 
-export BYPASS_MONGO_WRITES='yes'
-export BARD_HOST_URL="https://terra-bard-dev.appspot.com"

--- a/scripts/setup_mongo_dev.sh
+++ b/scripts/setup_mongo_dev.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+## PREREQUISITE
+## Set up your Github token in a file for use to access Vault
+
+## To set up your development environment before running ingest pipeline on the command line, run: 
+## source setup_mongo_dev.sh <path to your Github token file>
+
+VAULT_TOKEN_PATH="$1"
+if [[ -z "$VAULT_TOKEN_PATH" ]]
+then
+  echo "You must provide a path to a Github token to proceed"
+  exit 1
+fi
+vault login -method=github token=$(cat $VAULT_TOKEN_PATH)
+if [[ $? -ne 0 ]]
+then
+  echo "Unable to authenticate into vault"
+  exit 1
+fi
+
+export BROAD_USER=`whoami`
+export MONGODB_USERNAME='single_cell'
+export DATABASE_NAME='single_cell_portal_development'
+export MONGODB_PASSWORD=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/user | grep password | awk '{ print $2 }' `
+export DATABASE_HOST=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/hostname | grep ip | awk '{ $2=substr($2,2,length($2)-2); print $2 }' ` 
+export BYPASS_MONGO_WRITES='yes'
+export BARD_HOST_URL="https://terra-bard-dev.appspot.com"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -74,11 +74,11 @@ GeneExpression.load = mock_expression_load
 
 # Mixpanel logging needs config object instantiated
 # tests should bypass mongo check for input BSON values
-os.environ["BYPASS_MONGO_INPUT_VALIDATION"] = "yes"
+os.environ["BYPASS_MONGO_WRITES"] = "yes"
 # Initialize global variables]
 config.init("5d276a50421aa9117c982845", "5dd5ae25421aa910a723a337")
 # restore environment variable to unset state
-del os.environ['BYPASS_MONGO_INPUT_VALIDATION']
+del os.environ['BYPASS_MONGO_WRITES']
 
 
 class IngestTestCase(unittest.TestCase):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -46,7 +46,6 @@ from ingest_pipeline import (
     validate_arguments,
     IngestPipeline,
     exit_pipeline,
-    prepare_for_exit,
     run_ingest,
 )
 from expression_files.expression_files import GeneExpression
@@ -218,10 +217,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
 
         with self.assertRaises(SystemExit) as cm:
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
     def test_empty_mtx_file(self):
@@ -256,10 +252,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
 
         with self.assertRaises(SystemExit) as cm:
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
     @patch(
@@ -524,10 +517,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
 
         with self.assertRaises(SystemExit) as cm:
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
     def test_bad_metadata_file(self):
@@ -548,10 +538,7 @@ class IngestTestCase(unittest.TestCase):
         ]
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
         with self.assertRaises(SystemExit) as cm:
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
     def test_bad_metadata_file_contains_coordinates(self):
@@ -573,10 +560,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
 
         with self.assertRaises(SystemExit) as cm:
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
     def test_good_cluster_file(self):
@@ -622,10 +606,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
 
         with self.assertRaises(SystemExit) as cm:
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
     def test_bad_cluster_missing_coordinate_file(self):
@@ -646,10 +627,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
 
         with self.assertRaises(SystemExit) as cm:
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
     @patch("ingest_pipeline.IngestPipeline.load_subsample", return_value=0)
@@ -694,10 +672,7 @@ class IngestTestCase(unittest.TestCase):
         ]
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
         with self.assertRaises(SystemExit) as cm, self.assertRaises(ValueError):
-            exit_status = prepare_for_exit(
-                ingest, status, status_cell_metadata, arguments
-            )
-            exit_pipeline(exit_status)
+            exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
 
 

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -22,6 +22,7 @@ def mock_post_event(props):
             "fileName": "File_name.txt",
             "fileType": "Expression matrix",
             "fileSize": 400,
+            "logger": "ingest-pipeline",
             "appId": "single-cell-portal",
             "functionName": "ingest_expression",
         },

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -22,6 +22,7 @@ def mock_post_event(props):
             "fileName": "File_name.txt",
             "fileType": "Expression matrix",
             "fileSize": 400,
+            "trigger": "upload",
             "logger": "ingest-pipeline",
             "appId": "single-cell-portal",
             "functionName": "ingest_expression",

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -95,19 +95,19 @@ class TestValidateMetadata(unittest.TestCase):
         # incorrectly delimited value in numeric column
         self.assertIn(
             "disease__time_since_onset: '12,2' in '12,2' does not match expected 'number' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "comma-delimited values for array metadata should fail",
         )
         # incorrectly delimited value in boolean column
         self.assertIn(
             "disease__treated: 'True,False' in 'True,False' does not match expected 'boolean' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "comma-delimited values for array metadata should fail",
         )
         # partial correctly delimited value in numeric column should still fail
         self.assertIn(
             "disease__time_since_onset: '3,1' in '36|3,1' does not match expected 'number' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "incorrectly delimited values for array metadata should fail",
         )
 
@@ -153,7 +153,7 @@ class TestValidateMetadata(unittest.TestCase):
             "Row should not be altered if label for required ontology is missing",
         )
         self.assertEqual(
-            metadata.issues["error"]["ontology"],
+            metadata.issues["error"]["content"],
             {
                 'disease: required column "disease__ontology_label" missing data': [
                     "test1"
@@ -178,7 +178,7 @@ class TestValidateMetadata(unittest.TestCase):
             "Row should have column ontology_label added with value of empty array",
         )
         self.assertEqual(
-            metadata.issues["error"]["ontology"],
+            metadata.issues["error"]["content"],
             {
                 'disease: required column "disease__ontology_label" missing data': [
                     "test1"
@@ -207,7 +207,7 @@ class TestValidateMetadata(unittest.TestCase):
             "nan should be converted to empty array",
         )
         self.assertEqual(
-            metadata.issues["error"]["ontology"],
+            metadata.issues["error"]["content"],
             {
                 'disease: required column "disease__ontology_label" missing data': [
                     "test1"
@@ -232,7 +232,7 @@ class TestValidateMetadata(unittest.TestCase):
             "Row should not be altered if label for required ontology is missing",
         )
         self.assertEqual(
-            metadata.issues["error"]["ontology"],
+            metadata.issues["error"]["content"],
             {'organ: required column "organ__ontology_label" missing data': ["test1"]},
             "unexpected error reporting",
         )
@@ -249,7 +249,7 @@ class TestValidateMetadata(unittest.TestCase):
             "Row should have column ontology_label added with value of empty string",
         )
         self.assertEqual(
-            metadata.issues["error"]["ontology"],
+            metadata.issues["error"]["content"],
             {'organ: required column "organ__ontology_label" missing data': ["test1"]},
             "unexpected error reporting",
         )
@@ -270,7 +270,7 @@ class TestValidateMetadata(unittest.TestCase):
             "nan should be converted to empty string",
         )
         self.assertEqual(
-            metadata.issues["error"]["ontology"],
+            metadata.issues["error"]["content"],
             {'organ: required column "organ__ontology_label" missing data': ["test1"]},
             "unexpected error reporting",
         )
@@ -503,7 +503,7 @@ class TestValidateMetadata(unittest.TestCase):
         #   duplicate CellIDs are not permitted
         self.assertIn(
             "Duplicate CellID(s) in metadata file",
-            metadata.issues["error"]["format"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "Duplicate CellID(s) in metadata file should result in error",
         )
 
@@ -528,7 +528,7 @@ class TestValidateMetadata(unittest.TestCase):
         #   value provided not a number for 'organism_age'
         self.assertIn(
             "organism_age: \"foo\" does not match expected type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "ontology_label without ontology ID data results in error, even for non-required metadata",
         )
         self.teardown_metadata(metadata)
@@ -672,41 +672,41 @@ class TestValidateMetadata(unittest.TestCase):
         #     group instead of numeric: organism_age
         self.assertIn(
             'organism_age: \"group\" annotation in metadata file conflicts with metadata convention. Convention expects \"numeric\" values.',
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         #     numeric instead of group: biosample_type
         self.assertIn(
             'biosample_type: \"numeric\" annotation in metadata file conflicts with metadata convention. Convention expects \"group\" values.',
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         # invalid array-based metadata type: disease__time_since_onset
         self.assertIn(
             "disease__time_since_onset: 'three' in '36|three|1' does not match expected 'number' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         self.assertIn(
             "disease__time_since_onset: 'zero' in 'zero' does not match expected 'number' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         # invalid boolean value: disease__treated
         self.assertIn(
             "disease__treated: 'T' in 'T|F' does not match expected 'boolean' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         self.assertIn(
             "disease__treated: 'F' in 'F' does not match expected 'boolean' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         # non-uniform unit values: organism_age__unit
         self.assertIn(
             "disease__time_since_onset__unit: values for each unit metadata required to be uniform",
-            metadata.issues["error"]["convention"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "Ontology_label values for units should be uniform",
         )
         # missing ontology ID or label for required metadata: organ
@@ -724,7 +724,7 @@ class TestValidateMetadata(unittest.TestCase):
         # invalid header content: donor info (only alphanumeric or underscore allowed)
         self.assertIn(
             "donor info: only alphanumeric characters and underscore allowed in metadata name",
-            metadata.issues["error"]["metadata_name"].keys(),
+            metadata.issues["error"]["format"].keys(),
             "metadata names must follow header rules (only alphanumeric or underscore allowed)",
         )
         self.teardown_metadata(metadata)
@@ -733,17 +733,17 @@ class TestValidateMetadata(unittest.TestCase):
         metadata = set_up_test("has_na_in_array.tsv")
         self.assertIn(
             "disease__time_since_onset: 'None' in 'None' does not match expected 'number' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "Non-numeric 'None' provided instead of numeric array should fail",
         )
         self.assertIn(
             "disease__treated: 'N/A' in 'True|N/A|False' does not match expected 'boolean' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "Non-boolean 'N/A' provided in boolean array should fail",
         )
         self.assertIn(
             "disease__treated: 'None' in 'FALSE|None' does not match expected 'boolean' type",
-            metadata.issues["error"]["type"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "Non-boolean 'None' provided in boolean array should fail",
         )
         self.teardown_metadata(metadata)
@@ -753,12 +753,12 @@ class TestValidateMetadata(unittest.TestCase):
         # missing ontology ID or label for required metadata
         self.assertIn(
             "organ: required column \"organ\" missing data",
-            metadata.issues["error"]["ontology"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "Missing required metadata should fail validation",
         )
         self.assertIn(
             "species: required column \"species__ontology_label\" missing data",
-            metadata.issues["error"]["ontology"].keys(),
+            metadata.issues["error"]["content"].keys(),
             "Missing required metadata should fail validation",
         )
         # NA value in required field (ontology)
@@ -913,7 +913,7 @@ class TestValidateMetadata(unittest.TestCase):
         )
 
         self.assertEqual(
-            list(metadata.issues["error"]["type"].keys())[0],
+            list(metadata.issues["error"]["content"].keys())[0],
             'percent_mt: supplied value 07.juil is not numeric',
             "expected error message not generated",
         )


### PR DESCRIPTION
Adding Mixpanel logging to ingest pipeline errors. This PR addresses logging of errors that use the store_validation_issue from the Annotation Class. Logging expression matrix ingest errors requires a different approach and will be addressed in follow on ticket SCP-4037.

This PR adds a "file-validation" event to Mixpanel logging upon completion of an ingest pipeline run. The event has the following properties ingest pipeline has not reported before:

- logger - always set to "ingest-pipeline"
- trigger - "sync" if study file has remote_location set
                "dev_mode" if BYPASS_MONGO_WRITES is set to "yes"
                "upload" if neither of the above are true
- status - success|failure of the ingest pipeline job
- errorTypes - aligned with errorType used in CSFV
- errors - array of error messages sent to user
- numErrorTypes
- numErrors

This PR adds the option to bypass input validations and writes to MongoDB for development work. In the scripts directory, example script `setup_mongo_dev` sets up environment variables that:
   - set up access to remote Mongo instance
   - BYPASS_MONGO_WRITES='yes' bypasses input validation and writes
   - BARD_HOST_URL set to log events to Mixpanel dev
   If mixpanel logging during development is not needed, please:
      unset BARD_HOST_URL
	
To test:

1. via command line, set up to run in developer mode (can use `setup_mongo_dev` from scripts directory).
2. from ingest directory, run this command the indicated scp-ingest-pipeline repo file or a file of your choice:
python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 ingest_cell_metadata --cell-metadata-file ../tests/data/annotation/metadata/convention/has_na_in_required_fields.csv --study-accession SCPdev --ingest-cell-metadata --validate-convention

Check for the following CLI results and confirm they are reflected in the file-validation event in Mixpanel Dev:
  logger: ingest-pipeline
  trigger: dev_mode
  appId: single-cell-portal
  errorTypes: ['content:metadata:missing-required-values', 'content:schema-error']
  errors: ['organ: required column "organ" missing data', 'species: required column "species__ontology_label" missing data', 'One or more errors from jsonschema validation of metadata content against Alexandria Convention detected']
  numErrortypes: 2
  numErrors: 3
  functionName: ingest_cell_metadata
  status: failure

Note: the following are dummy values hard-coded when using dev_mode (no info from Mongo on studyFile):
  distinct_id: 2f30ec50-a04d-4d43-8fd1-b136a2045079
  studyAccession: SCPdev
  fileType: input_validation_bypassed
  fileSize: 1
  trigger: dev_mode

(optional) Additional validation of trigger functionality

Test for trigger: upload
1. set your local instance to use docker image:
`gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_mixpanel_logging:623864e`
2. upload a file that will pass CSFV and confirm that the mixpanel file-validation event with logger: ingest-pipeline shows trigger: upload

Test for trigger: sync
1. using above docker image, gsutil a file to a study bucket for a study in your local dev environment
2. sync the file and confirm that the mixpanel file-validation event with logger: ingest-pipeline shows trigger: sync

This PR support SCP-3921
