### PR TITLE
Fix conventional single numeric array-based metadata value handing (SCP-4060)

### DIFF
--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -905,10 +905,9 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
                 "content:invalid-type:value-type-mismatch",
                 associated_info=[id_for_error_detail],
             )
-        # This exception should only trigger if a single-value boolean array
+        # This exception should only trigger if a single-value array
         # metadata is being cast - the value needs to be passed as an array,
-        # it is already boolean via Pandas' inference processes
-        except AttributeError:
+        except (AttributeError, TypeError):
             try:
                 if "ontology" in convention["properties"][metadatum]:
                     value = regularize_ontology_id(value)


### PR DESCRIPTION
[Zendesk 269187](https://broadinstitute.zendesk.com/agent/tickets/269187) indicated an ingest error about float values that the study owner couldn't understand. This error turns out to be an unhandled exception where ingest did not correctly manage conventional single numeric array-based metadata values.

I've taken Constantine's metadata file and extracted just the head of the file (This avoids the content error that lurks in the file). It can be obtained at gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/manual_testing/Z269187.txt

To test: 
Configure your local instance to use docker image
`gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_iterable_float_bugfix:1a92c2b `

Confirm that ingest of file Z269187.txt succeeds.

This PR resolves SCP-4060