### PR TITLE
Adding Mixpanel logging to ingest pipeline expression matrix errors (SCP-4037)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,21 @@ vault read secret/kdux/scp/development/$BROAD_USER/mongo/hostname
 
 export DATABASE_HOST="<ip from Vault (omit brackets)>"
 ```
+
 For testing/development using ingest_pipeline.py on the command line, annotation file input validation and MongoDB writes can be bypassed if you set:
 (Note: this bypass does not currently apply to expression matrix ingest).
+
 ```
 export BYPASS_MONGO_WRITES='yes'
 ```
 
-
-If you are developing updates for MixPanel logging, set the Bard Host URL:
+If you are developing updates for Mixpanel logging, set the Bard host URL:
 
 ```
 
 export BARD_HOST_URL="https://terra-bard-dev.appspot.com"
 ```
+
 Be sure to `unset BARD_HOST_URL` when your updates are done, so development ingest events are not always sent to Mixpanel.
 
 If you are developing updates for Sentry logging, then set the DSN:
@@ -115,6 +117,7 @@ pytest
 ```
 
 Some common `pytest` usage examples (run in `/tests`):
+
 ```
 # Run all tests and see print() output
 pytest -s
@@ -126,7 +129,7 @@ pytest test_ingest.py
 pytest --cov=../ingest/
 ```
 
-For more, see https://docs.pytest.org/en/stable/usage.html.
+For more, see <https://docs.pytest.org/en/stable/usage.html>.
 
 # Use
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ brew install tabix
 ```
 
 Now get secrets from Vault to set environment variables needed to write to the database:
+(see also scripts/setup_mongo_dev.sh)
 
 ```
 export BROAD_USER="<username in your email address>"
@@ -59,6 +60,20 @@ vault read secret/kdux/scp/development/$BROAD_USER/mongo/hostname
 
 export DATABASE_HOST="<ip from Vault (omit brackets)>"
 ```
+For testing/development using ingest_pipeline.py on the command line, annotation file input validation and MongoDB writes can be bypassed if you set:
+(Note: this bypass does not currently apply to expression matrix ingest).
+```
+export BYPASS_MONGO_WRITES='yes'
+```
+
+
+If you are developing updates for MixPanel logging, set the Bard Host URL:
+
+```
+
+export BARD_HOST_URL="https://terra-bard-dev.appspot.com"
+```
+Be sure to `unset BARD_HOST_URL` when your updates are done, so development ingest events are not always sent to Mixpanel.
 
 If you are developing updates for Sentry logging, then set the DSN:
 

--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -225,9 +225,9 @@ class Annotations(IngestFiles):
         else:
             try:
                 category = issue_name.split(":")[0]
-        except (ValueError, TypeError):
-            msg = f'Expected parse on ":" to derive category from {issue_name}'
-            raise ValueError(msg)
+            except (ValueError, TypeError):
+                msg = f'Expected parse on ":" to derive category from {issue_name}'
+                raise ValueError(msg)
 
         if associated_info:
             self.issues[type][category][msg].extend(associated_info)
@@ -254,7 +254,6 @@ class Annotations(IngestFiles):
         else:
             msg = f'Unexpected lack of issue_name, {issue_name}, for Mixpanel logging'
             raise ValueError(msg)
-
 
     def validate_header_keyword(self):
         """Check header row starts with NAME (case-insensitive).

--- a/ingest/annotations.py
+++ b/ingest/annotations.py
@@ -223,7 +223,11 @@ class Annotations(IngestFiles):
         if issue_type:
             category = issue_type
         else:
-            category = issue_name.split(":")[0]
+            try:
+                category = issue_name.split(":")[0]
+        except (ValueError, TypeError):
+            msg = f'Expected parse on ":" to derive category from {issue_name}'
+            raise ValueError(msg)
 
         if associated_info:
             self.issues[type][category][msg].extend(associated_info)
@@ -231,20 +235,26 @@ class Annotations(IngestFiles):
             self.issues[type][category][msg] = None
 
         if category == "runtime":
-            # do not log runtime errors as file-validation failure errorType
+            # do not log runtime errors as file-validation failure errorType in Mixpanel
+            # runtime errors cause early exit of cell_metadata validation
+            # the error is reported to the user via report_issues()
             pass
-        else:
+        elif issue_name:
             # propagate detected warnings and errors to Mixpanel
-            if type == "error" and issue_name:
+            if type == "error":
                 if issue_name not in self.props["errorTypes"]:
                     self.props["errorTypes"].append(issue_name)
                 if msg not in self.props["errors"]:
                     self.props["errors"].append(msg)
-            elif type == "warn" and issue_name:
+            elif type == "warn":
                 if issue_name not in self.props["warningTypes"]:
                     self.props["warningTypes"].append(issue_name)
                 if msg not in self.props["warnings"]:
                     self.props["warnings"].append(msg)
+        else:
+            msg = f'Unexpected lack of issue_name, {issue_name}, for Mixpanel logging'
+            raise ValueError(msg)
+
 
     def validate_header_keyword(self):
         """Check header row starts with NAME (case-insensitive).

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -109,7 +109,7 @@ class CellMetadata(Annotations):
         if valid:
             return True
         else:
-            msg = "Header names can not be coordinate values \"X\", \"Y\", or \"Z\" (case insensitive)"
+            msg = 'Header names can not be coordinate values "X", "Y", or "Z" (case insensitive).'
             self.store_validation_issue(
                 "error", msg, "format:cap:metadata-no-coordinates"
             )

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -109,7 +109,7 @@ class CellMetadata(Annotations):
         if valid:
             return True
         else:
-            msg = "Header names can not be coordinate values x, y, or z (case insensitive)"
+            msg = "Header names can not be coordinate values \"X\", \"Y\", or \"Z\" (case insensitive)"
             self.store_validation_issue(
                 "error", msg, "format:cap:metadata-no-coordinates"
             )

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -111,9 +111,7 @@ class Clusters(Annotations):
         lower_cased_headers = [header.lower() for header in self.headers]
         for coordinate in ("x", "y"):
             if coordinate not in lower_cased_headers:
-                msg = (
-                    "Header must have coordinate values 'x' and 'y' (case insensitive)"
-                )
+                msg = "Header must have coordinate values \"X\" and \"Y\" (case insensitive)"
                 self.store_validation_issue(
                     "error", msg, "format:cap:cluster-coordinates"
                 )

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -92,7 +92,7 @@ class Clusters(Annotations):
             if annot_name.lower() in ("x", "y", "z"):
                 if self.file[annot_name].isna().any().bool():
                     is_valid = False
-                    msg = f"Missing coordinate values in {annot_name} column"
+                    msg = f"Missing coordinate values in {annot_name} column."
                     self.store_validation_issue(
                         "error", msg, "content:cluster:missing-coordinates-values"
                     )
@@ -111,7 +111,9 @@ class Clusters(Annotations):
         lower_cased_headers = [header.lower() for header in self.headers]
         for coordinate in ("x", "y"):
             if coordinate not in lower_cased_headers:
-                msg = "Header must have coordinate values \"X\" and \"Y\" (case insensitive)"
+                msg = (
+                    'Header must have coordinate values "X" and "Y" (case insensitive).'
+                )
                 self.store_validation_issue(
                     "error", msg, "format:cap:cluster-coordinates"
                 )

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -92,7 +92,7 @@ class Study:
         try:
             study_id = ObjectId(study_id)
         except Exception:
-            raise ValueError("Must pass in valid object ID for study ID")
+            raise ValueError("Must pass in valid object ID for study ID.")
         # set dummy accession if running in developer mode
         if bypass_mongo_writes():
             self.accession = "SCPdev"
@@ -105,7 +105,7 @@ class Study:
             )
             if not study:
                 raise ValueError(
-                    "Study ID is not registered with a study. Please provide a valid study ID"
+                    "Study ID is not registered with a study. Please provide a valid study ID."
                 )
             else:
                 self.__study = study.pop()
@@ -127,13 +127,13 @@ class StudyFile:
         try:
             study_file_id = ObjectId(study_file_id)
         except Exception:
-            raise ValueError("Must pass in valid object ID for study file ID")
+            raise ValueError("Must pass in valid object ID for study file ID.")
         if bypass_mongo_writes():
             # set dummy values if running in developer mode
             self.file_type = "input_validation_bypassed"
             self.file_size = 1
             self.file_name = str(study_file_id)
-            self.trigger = 'dev_mode'
+            self.trigger = 'dev-mode'
         else:
             query = MONGO_CONNECTION._client["study_files"].find({"_id": study_file_id})
             query_results = list(query)

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -174,7 +174,7 @@ class StudyFile:
                 self.file_type = self.study_file["file_type"]
                 self.file_size = self.study_file["upload_file_size"]
                 self.file_name = self.study_file["name"]
-                if self.study_file.get("remote_location") is not None:
-                    self.trigger = 'sync'
-                else:
+                if self.study_file.get("remote_location") == '':
                     self.trigger = 'upload'
+                else:
+                    self.trigger = 'sync'

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -174,10 +174,12 @@ class StudyFile:
                 self.file_type = self.study_file["file_type"]
                 self.file_size = self.study_file["upload_file_size"]
                 self.file_name = self.study_file["name"]
+                # when set, remote_location is the name of the file in the bucket
                 if self.study_file.get("remote_location") is not None:
-                    if self.study_file["remote_location"][:5] == "gs://":
-                        self.trigger = 'sync'
+                    if self.study_file["remote_location"] == "":
+                        self.trigger = 'upload'
                     else:
-                        self.trigger = "upload"
+                        self.trigger = 'sync'
+                # indicate trigger state for tests/mocks
                 else:
                     self.trigger = 'not set'

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -180,4 +180,4 @@ class StudyFile:
                     else:
                         self.trigger = "upload"
                 else:
-                    self.trigger = 'unknown'
+                    self.trigger = 'not set'

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -174,7 +174,10 @@ class StudyFile:
                 self.file_type = self.study_file["file_type"]
                 self.file_size = self.study_file["upload_file_size"]
                 self.file_name = self.study_file["name"]
-                if self.study_file.get("remote_location") == '':
-                    self.trigger = 'upload'
+                if self.study_file.get("remote_location") is not None:
+                    if self.study_file["remote_location"][:5] == "gs://":
+                        self.trigger = 'sync'
+                    else:
+                        self.trigger = "upload"
                 else:
-                    self.trigger = 'sync'
+                    self.trigger = 'unknown'

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -68,6 +68,24 @@ class MetricProperties:
             if self.__properties.get(prop):
                 self.__properties[num_prop] = len(self.__properties[prop])
 
+    def append_issue(self, props):
+        """Add error/warning properties to MetricsProperties
+            without clobbering
+        """
+        if props:
+            updated_props = {}
+            for prop in ["errorTypes", "errors", "warningTypes", "warnings"]:
+                if prop in self.__properties:
+                    updated_props.setdefault(prop, []).extend(self.__properties[prop])
+                if prop in props:
+                    updated_props.setdefault(prop, []).extend(props[prop])
+            for key in updated_props.keys():
+                if key in ["errorTypes", "warningTypes"]:
+                    self.__properties[key] = set(updated_props[key])
+                else:
+                    self.__properties[key] = updated_props[key]
+            self.set_mixpanel_nums()
+
 
 def bypass_mongo_writes():
     """Check if developer has set environment variable to bypass writing data to MongoDB

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -58,6 +58,15 @@ class MetricProperties:
     def update(self, props):
         if props:
             self.__properties = {**self.__properties, **props}
+        self.set_mixpanel_nums()
+
+    def set_mixpanel_nums(self):
+        """Derive count for each type of Mixpanel property
+        """
+        for prop in ["errorTypes", "errors", "warningTypes", "warnings"]:
+            num_prop = "num" + prop.capitalize()
+            if self.__properties.get(prop):
+                self.__properties[num_prop] = len(self.__properties[prop])
 
 
 def bypass_mongo_writes():

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -72,6 +72,7 @@ class MetricProperties:
         """Add error/warning properties to MetricsProperties
             without clobbering
         """
+
         if props:
             updated_props = {}
             for prop in ["errorTypes", "errors", "warningTypes", "warnings"]:
@@ -81,7 +82,7 @@ class MetricProperties:
                     updated_props.setdefault(prop, []).extend(props[prop])
             for key in updated_props.keys():
                 if key in ["errorTypes", "warningTypes"]:
-                    self.__properties[key] = set(updated_props[key])
+                    self.__properties[key] = list(set(updated_props[key]))
                 else:
                     self.__properties[key] = updated_props[key]
             self.set_mixpanel_nums()

--- a/ingest/expression_files/dense_ingestor.py
+++ b/ingest/expression_files/dense_ingestor.py
@@ -204,18 +204,21 @@ class DenseIngestor(GeneExpression, IngestFiles):
                 GeneExpression.log_for_mixpanel(
                     "error", "content:type:not-numeric", msg
                 )
-                raise ValueError("Score '{expression_score}' is not valid")
+                raise ValueError("Invalid expression score \"{expression_score}\"")
         return valid_expression_scores, associated_cells
 
     @staticmethod
     def check_unique_header(header: List):
         """Confirms header has no duplicate values"""
         if len(set(header)) != len(header):
-            msg = "Duplicate header values are not allowed"
+            seen = set()
+            dupes = [x for x in header if x in seen or seen.add(x)]
+            msg = "Duplicate header values are not allowed. "
+            msg += f'Duplicates include: \"{", ".join(list(dupes)[:3])}\"'
             GeneExpression.log_for_mixpanel(
                 "error", "content:duplicate:cells-within-file", msg
             )
-            raise ValueError("Duplicate header values are not allowed")
+            raise ValueError(msg)
         return True
 
     @staticmethod
@@ -227,7 +230,7 @@ class DenseIngestor(GeneExpression, IngestFiles):
                 GeneExpression.log_for_mixpanel("error", "format:cap:no-empty", msg)
                 raise ValueError(msg)
             if value.lower() == "nan":
-                msg = f"{value} is not allowed as a header value"
+                msg = f"\"{value}\" is not allowed as a header value"
                 GeneExpression.log_for_mixpanel("error", "format:cap:no-empty", msg)
                 raise ValueError(msg)
 
@@ -246,7 +249,7 @@ class DenseIngestor(GeneExpression, IngestFiles):
             return True
         if DenseIngestor.is_r_formatted_file(header, row)[0]:
             return True
-        msg = "Required 'GENE' header is not present"
+        msg = "Required \"GENE\" header is not present"
         GeneExpression.log_for_mixpanel("error", "format:cap:missing-gene-column", msg)
         raise ValueError(msg)
 

--- a/ingest/expression_files/dense_ingestor.py
+++ b/ingest/expression_files/dense_ingestor.py
@@ -172,8 +172,8 @@ class DenseIngestor(GeneExpression, IngestFiles):
         if len(scores) != len(cells):
             msg = (
                 "Number of cell and expression values must be the same. "
-                f"Found row with {len(scores)} expression values."
-                f"Header contains {len(cells)} cells"
+                f"Found row with {len(scores)} expression values. "
+                f"Header contains {len(cells)} cells."
             )
             GeneExpression.log_for_mixpanel(
                 "error", "format:mismatch-column-number", msg
@@ -200,11 +200,11 @@ class DenseIngestor(GeneExpression, IngestFiles):
                 )
                 raise ValueError(msg)
             except Exception:
-                msg = "Score '{expression_score}' is not valid"
+                msg = "Score '{expression_score}' is not valid."
                 GeneExpression.log_for_mixpanel(
                     "error", "content:type:not-numeric", msg
                 )
-                raise ValueError("Invalid expression score \"{expression_score}\"")
+                raise ValueError('Invalid expression score "{expression_score}".')
         return valid_expression_scores, associated_cells
 
     @staticmethod
@@ -226,11 +226,11 @@ class DenseIngestor(GeneExpression, IngestFiles):
         """Validates there are no empty header values"""
         for value in header:
             if value == "" or value.isspace():
-                msg = "Header values cannot be blank"
+                msg = "Header values cannot be blank."
                 GeneExpression.log_for_mixpanel("error", "format:cap:no-empty", msg)
                 raise ValueError(msg)
             if value.lower() == "nan":
-                msg = f"\"{value}\" is not allowed as a header value"
+                msg = f'"{value}" is not allowed as a header value.'
                 GeneExpression.log_for_mixpanel("error", "format:cap:no-empty", msg)
                 raise ValueError(msg)
 
@@ -249,7 +249,7 @@ class DenseIngestor(GeneExpression, IngestFiles):
             return True
         if DenseIngestor.is_r_formatted_file(header, row)[0]:
             return True
-        msg = "Required \"GENE\" header is not present"
+        msg = 'Required "GENE" header is not present.'
         GeneExpression.log_for_mixpanel("error", "format:cap:missing-gene-column", msg)
         raise ValueError(msg)
 

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -184,7 +184,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
             msg = (
                 "Duplicate values are not allowed. "
                 f"There are {amount_of_duplicates} duplicates "
-                f"in the {file_type} file"
+                f"in the {file_type} file."
             )
             raise ValueError(msg)
         return True
@@ -211,13 +211,13 @@ class MTXIngestor(GeneExpression, IngestFiles):
                     # First line w/o '%' is mtx dimension. So skip this line (+1)
                     return count + 1
                 except ValueError:
-                    msg = "Only header, comment lines starting with \"%\", and numeric data allowed in MTX file."
+                    msg = 'Only header, comment lines starting with "%", and numeric data allowed in MTX file.'
                     GeneExpression.log_for_mixpanel(
                         "error", "content:type:not-numeric", msg
                     )
                     raise ValueError(msg)
                 except IndexError:
-                    msg = "MTX file cannot start with a space"
+                    msg = "MTX file cannot start with a space."
                     GeneExpression.log_for_mixpanel(
                         "error", "format:cap:leading-space", msg
                     )
@@ -237,7 +237,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
                     return dimensions
                 except Exception as e:
                     raise e
-        msg = "MTX file did not contain expression data"
+        msg = "MTX file did not contain expression data."
         GeneExpression.log_for_mixpanel("error", "content:no-expression-data", msg)
         raise ValueError(msg)
 
@@ -371,7 +371,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
                 current_idx = int(raw_gene_idx)
                 if current_idx != prev_idx:
                     if not current_idx > prev_idx:
-                        raise ValueError("MTX file must be sorted")
+                        raise ValueError("MTX file must be sorted.")
                     GeneExpression.dev_logger.debug(
                         f"Processing {self.genes[prev_idx - 1]}"
                     )

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -211,7 +211,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
                     # First line w/o '%' is mtx dimension. So skip this line (+1)
                     return count + 1
                 except ValueError:
-                    msg = "Only header, comment lines starting with '%', and numeric data allowed in MTX file."
+                    msg = "Only header, comment lines starting with \"%\", and numeric data allowed in MTX file."
                     GeneExpression.log_for_mixpanel(
                         "error", "content:type:not-numeric", msg
                     )
@@ -237,7 +237,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
                     return dimensions
                 except Exception as e:
                     raise e
-        msg = "MTX file did not contain data"
+        msg = "MTX file did not contain expression data"
         GeneExpression.log_for_mixpanel("error", "content:no-expression-data", msg)
         raise ValueError(msg)
 

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -8,18 +8,7 @@ a remote MongoDB instance.
 PREREQUISITES
 See https://github.com/broadinstitute/scp-ingest-pipeline#prerequisites
 
-DEVELOPER SETUP (see also ../scripts/setup_mongo_dev.sh)
-To run ingest_pipeline on the command line, set the following environment variable(s):
-Set up access to your developer MongoDB instance
-    export MONGODB_USERNAME='single_cell'
-    export DATABASE_NAME='single_cell_portal_development'
-leverage Vault to securely set up the following environment variable(s):
-    MONGODB_PASSWORD
-    DATABASE_HOST
-Bypass MongoDB check for ingest file info in MongoDB and bypass writing results to MongoDB
-    export BYPASS_MONGO_WRITES='yes'
-(optional) To have validation events report to Mixpanel, set:
-    export BARD_HOST_URL="https://terra-bard-dev.appspot.com"
+DEVELOPER SETUP (see README.md/Install and ../scripts/setup_mongo_dev.sh)
 
 EXAMPLES
 # Takes expression file and stores it into MongoDB

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -311,8 +311,10 @@ class IngestPipeline:
                 )
             self.expression_ingestor.execute_ingest()
         except Exception as e:
+            self.report_validation("failure")
             log_exception(IngestPipeline.dev_logger, IngestPipeline.user_logger, e)
             return 1
+        self.report_validation("success")
         return 0
 
     # More work needs to be done to fully remove ingest from IngestPipeline
@@ -334,7 +336,7 @@ class IngestPipeline:
                         "Cell metadata file conforms to metadata convention"
                     )
                 else:
-                    update_mixpanel_props(self.cell_metadata.props)
+                    config.get_metric_properties().update(self.cell_metadata.props)
                     self.report_validation("failure")
                     return 1
             self.report_validation("success")
@@ -357,7 +359,7 @@ class IngestPipeline:
             return status if status is not None else 1
         else:
             report_issues(self.cell_metadata)
-            update_mixpanel_props(self.cell_metadata.props)
+            config.get_metric_properties().update(self.cell_metadata.props)
             self.report_validation("failure")
             IngestPipeline.user_logger.error("Cell metadata file format invalid")
             return 1
@@ -378,7 +380,7 @@ class IngestPipeline:
         # Incorrect file format
         else:
             report_issues(self.cluster)
-            update_mixpanel_props(self.cluster.props)
+            config.get_metric_properties().update(self.cluster.props)
             self.report_validation("failure")
             IngestPipeline.user_logger.error("Cluster file format invalid")
             return 1
@@ -436,27 +438,8 @@ class IngestPipeline:
 
     def report_validation(self, status):
         self.props["status"] = status
-        update_mixpanel_props(self.props)
+        config.get_metric_properties().update(self.props)
         MetricsService.log("file-validation", config.get_metric_properties())
-
-
-def update_mixpanel_props(props):
-    """Update validation issues from props data structure to
-        metric_properties for Mixpanel logging
-    """
-    props = set_mixpanel_nums(props)
-    metrics_dump = config.get_metric_properties().get_properties()
-    metrics_dump.update(props)
-
-
-def set_mixpanel_nums(props):
-    """Derive count for each type of Mixpanel property
-    """
-    for prop in ["errorTypes", "errors", "warningTypes", "warnings"]:
-        num_prop = "num" + prop.capitalize()
-        if props.get(prop):
-            props[num_prop] = len(props[prop])
-    return props
 
 
 def run_ingest(ingest, arguments, parsed_args):
@@ -553,11 +536,10 @@ def main() -> None:
     )
     ingest = IngestPipeline(**arguments)
     status, status_cell_metadata = run_ingest(ingest, arguments, parsed_args)
-    # If in developer mode, print metrics properties
-    if config.bypass_mongo_writes():
-        metrics_dump = config.get_metric_properties().get_properties()
-        for key in metrics_dump.keys():
-            print(f'{key}: {metrics_dump[key]}')
+    # Print metrics properties
+    metrics_dump = config.get_metric_properties().get_properties()
+    for key in metrics_dump.keys():
+        print(f'{key}: {metrics_dump[key]}')
 
     # Log Mixpanel events
     MetricsService.log(config.get_parent_event_name(), config.get_metric_properties())

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -8,7 +8,7 @@ a remote MongoDB instance.
 PREREQUISITES
 See https://github.com/broadinstitute/scp-ingest-pipeline#prerequisites
 
-DEVELOPER SETUP (see README.md/Install and ../scripts/setup_mongo_dev.sh)
+DEVELOPER SETUP (see README.md#Install and ../scripts/setup_mongo_dev.sh)
 
 EXAMPLES
 # Takes expression file and stores it into MongoDB

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -345,7 +345,7 @@ class IngestPipeline:
                         "Cell metadata file conforms to metadata convention"
                     )
                 else:
-                    push_mixpanel_props(self.cell_metadata.props)
+                    update_mixpanel_props(self.cell_metadata.props)
                     self.report_validation("failure")
                     return 1
             self.report_validation("success")
@@ -368,7 +368,7 @@ class IngestPipeline:
             return status if status is not None else 1
         else:
             report_issues(self.cell_metadata)
-            push_mixpanel_props(self.cell_metadata.props)
+            update_mixpanel_props(self.cell_metadata.props)
             self.report_validation("failure")
             IngestPipeline.user_logger.error("Cell metadata file format invalid")
             return 1
@@ -389,7 +389,7 @@ class IngestPipeline:
         # Incorrect file format
         else:
             report_issues(self.cluster)
-            push_mixpanel_props(self.cluster.props)
+            update_mixpanel_props(self.cluster.props)
             self.report_validation("failure")
             IngestPipeline.user_logger.error("Cluster file format invalid")
             return 1
@@ -447,12 +447,12 @@ class IngestPipeline:
 
     def report_validation(self, status):
         self.props["status"] = status
-        push_mixpanel_props(self.props)
+        update_mixpanel_props(self.props)
         MetricsService.log("file-validation", config.get_metric_properties())
 
 
-def push_mixpanel_props(props):
-    """Push validation issues from props data structure to
+def update_mixpanel_props(props):
+    """Update validation issues from props data structure to
         metric_properties for Mixpanel logging
     """
     props = set_mixpanel_nums(props)
@@ -461,7 +461,7 @@ def push_mixpanel_props(props):
 
 
 def set_mixpanel_nums(props):
-    """
+    """Derive count for each type of Mixpanel property
     """
     for prop in ["errorTypes", "errors", "warningTypes", "warnings"]:
         num_prop = "num" + prop.capitalize()

--- a/ingest/monitoring/metrics_service.py
+++ b/ingest/monitoring/metrics_service.py
@@ -31,6 +31,11 @@ class MetricsService:
     @classmethod
     def log(cls, event_name, props={}):
         properties = {"event": event_name, "properties": props.get_properties()}
+        # to avoid loss of logging due to Bard overflow errors
+        # report numErrors and numWarnings but not actual messages
+        for prop in ["errors", "warnings"]:
+            if properties["properties"].get(prop):
+                del properties["properties"][prop]
 
         post_body = json.dumps(properties)
         MetricsService.post_event(post_body)

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -419,7 +419,7 @@ def validate_schema(json, metadata):
     except jsonschema.SchemaError:
         error_msg = "Invalid metadata convention file, cannot validate metadata."
         metadata.store_validation_issue(
-            "error", error_msg, "runtime:invalid_convention", issue_type="runtime"
+            "error", error_msg, "runtime:invalid-convention", issue_type="runtime"
         )
         return None
 
@@ -752,7 +752,7 @@ def compare_type_annots_to_convention(metadata, convention):
                     f'Convention expects "{expected}" values.'
                 )
                 metadata.store_validation_issue(
-                    "error", error_msg, "content:invalid-type:value-type-mismatch"
+                    "error", error_msg, "content:type:value-type-mismatch"
                 )
         except TypeError:
             for k, v in annot_equivalents.items():
@@ -902,7 +902,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
             metadata.store_validation_issue(
                 "error",
                 error_msg,
-                "content:invalid-type:value-type-mismatch",
+                "content:type:value-type-mismatch",
                 associated_info=[id_for_error_detail],
             )
         # This exception should only trigger if a single-value boolean array
@@ -937,7 +937,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
             metadata.store_validation_issue(
                 "error",
                 error_msg,
-                "content:invalid-type:value-type-mismatch",
+                "content:type:value-type-mismatch",
                 associated_info=[id_for_error_detail],
             )
         # particular metadatum is not in convention, metadata does not need
@@ -985,7 +985,7 @@ def process_metadata_row(metadata, convention, line):
                     metadata.store_validation_issue(
                         "error",
                         msg,
-                        "content:invalid-type:not-numeric",
+                        "content:type:not-numeric",
                         associated_info=row_info["CellID"],
                     )
                     dev_logger.error(msg)

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -284,7 +284,7 @@ class OntologyRetriever:
                 msg = f"{property_name}: No match found in EBI OLS for provided ontology ID: {term}"
                 raise ValueError(msg)
         elif not metadata_ontology:
-            msg = f'No result from EBI OLS for provided ontology shortname "{ontology_shortname}"'
+            msg = f'No result from EBI OLS for provided ontology shortname "{ontology_shortname}".'
             print(msg)
             user_logger.error(msg)
             raise ValueError(
@@ -292,7 +292,7 @@ class OntologyRetriever:
             )
         else:
             msg = (
-                f"encountered issue retrieving {ontology_urls} or {ontology_shortname}"
+                f"Encountered issue retrieving {ontology_urls} or {ontology_shortname}."
             )
             print(msg)
             user_logger.info(msg)
@@ -332,7 +332,7 @@ def parse_organ_region_ontology_id(term):
             # remove leading zeroes (e.g. '000786' => '786') since the dictionary file doesn't have them
             return term_id.lstrip("0")
         else:
-            msg = f'organ_region: Invalid ontology code, "{ontology_shortname}"'
+            msg = f'organ_region: Invalid ontology code, "{ontology_shortname}".'
             raise ValueError(msg)
     except (TypeError, ValueError):
         # when term value is empty string -> TypeError, convert this to a value error
@@ -354,7 +354,7 @@ def fetch_allen_mouse_brain_atlas_remote():
         return region_dict
     # if we can't get the file in GitHub for validation record error
     except:  # noqa E722
-        msg = "Unable to read GitHub-hosted organ_region ontology file"
+        msg = "Unable to read GitHub-hosted organ_region ontology file."
         dev_logger.exception(msg)
         raise RuntimeError(msg)
 
@@ -493,7 +493,7 @@ def validate_cells_unique(metadata):
         valid = True
     else:
         dups = list_duplicates(metadata.cells)
-        msg = "Duplicate CellID(s) in metadata file"
+        msg = "Duplicate CellID(s) in metadata file."
         metadata.store_validation_issue(
             "error", msg, "content:duplicate:cells-within-file", associated_info=dups
         )
@@ -506,7 +506,7 @@ def insert_array_ontology_label_row_data(
     cell_id = row["CellID"]
     # if there are differing numbers of id/label values, and not empty, log error and don't try to fix
     if len(row[property_name]) != len(row[ontology_label]) and row[ontology_label]:
-        msg = f"{property_name}: mismatched # of {property_name} and {ontology_label} values"
+        msg = f"{property_name}: mismatched # of {property_name} and {ontology_label} values."
         metadata.store_validation_issue(
             "error", msg, "ontology:array-length-mismatch", associated_info=[cell_id]
         )
@@ -544,7 +544,7 @@ def insert_array_ontology_label_row_data(
                 msg = (
                     f'{property_name}: unable to lookup "{id}" - '
                     f"cannot propagate array of labels for {property_name};"
-                    f"may cause inaccurate error reporting for {property_name}"
+                    f"may cause inaccurate error reporting for {property_name}."
                 )
                 metadata.store_validation_issue(
                     "error",
@@ -594,7 +594,7 @@ def insert_ontology_label_row_data(
             )
         except BaseException as e:
             print(e)
-            msg = f"Optional column {ontology_label} empty and could not be resolved from {property_name} column value {row[property_name]}"
+            msg = f"Optional column {ontology_label} empty and could not be resolved from {property_name} column value {row[property_name]}."
             metadata.store_validation_issue(
                 "warn", msg, "ontology:label-lookup-error", associated_info=[cell_id]
             )
@@ -885,7 +885,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
         except ValueError:
             msg = (
                 f"{metadatum}: '{element}' in '{value}' does not match "
-                f"expected '{lookup_metadata_type(convention, metadatum)}' type"
+                f"expected '{lookup_metadata_type(convention, metadatum)}' type."
             )
             metadata.store_validation_issue(
                 "error",
@@ -920,7 +920,7 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
             )(value)
             cast_metadata[metadatum] = cast_value
         except ValueError:
-            msg = f'{metadatum}: "{value}" does not match expected type'
+            msg = f'{metadatum}: "{value}" does not match expected type.'
             metadata.store_validation_issue(
                 "error",
                 msg,
@@ -965,10 +965,10 @@ def process_metadata_row(metadata, convention, line):
                     # but the value 0.0825991189427313 was validly supplied as a numeric
                     try:
                         float(v)
-                        msg = f"{k}: one or more values in data column are not numeric"
+                        msg = f"{k}: one or more values in data column are not numeric."
                     # only true non-numerics should be reported in detail
                     except ValueError:
-                        msg = f"{k}: supplied value {v} is not numeric"
+                        msg = f"{k}: supplied value {v} is not numeric."
                     metadata.store_validation_issue(
                         "error",
                         msg,
@@ -985,7 +985,7 @@ def process_metadata_row(metadata, convention, line):
             if is_array_metadata(convention, k):
                 for element in v.split("|"):
                     if value_is_nan(element) or is_empty_string(element):
-                        msg = f"{k}: NA, NaN, and None are not accepted values for arrays or required fields"
+                        msg = f"{k}: NA, NaN, and None are not accepted values for arrays or required fields."
                         metadata.store_validation_issue(
                             "error",
                             msg,
@@ -1185,7 +1185,7 @@ def validate_collected_ontology_data(metadata, convention):
                     ):
                         msg = (
                             f'{property_name}: ontology label required for "{ontology_id}" '
-                            f'to cross-check for data entry error"'
+                            f'to cross-check for data entry error.'
                         )
                         metadata.store_validation_issue(
                             "error",
@@ -1198,7 +1198,7 @@ def validate_collected_ontology_data(metadata, convention):
                     else:
                         msg = (
                             f'{property_name}: input ontology_label "{ontology_label}" '
-                            f'does not match {ontology_source_name} lookup "{matched_label_for_id}" for ontology id "{ontology_id}"'
+                            f'does not match {ontology_source_name} lookup "{matched_label_for_id}" for ontology id "{ontology_id}".'
                         )
                         metadata.store_validation_issue(
                             "error",
@@ -1239,7 +1239,7 @@ def confirm_uniform_units(metadata, convention):
             # existence of unit metadata is enforced by jsonschema
             # any empty cells in a unit column are okay to be empty
             if metadata.file[name].nunique(dropna=True).values[0] != 1:
-                msg = f"{name}: values for each unit metadata required to be uniform"
+                msg = f"{name}: values for each unit metadata required to be uniform."
                 metadata.store_validation_issue("error", msg, "content:uniform-units")
 
 
@@ -1291,7 +1291,7 @@ def review_metadata_names(metadata):
         if not allowed_char.match(name):
             msg = (
                 f"{name}: only alphanumeric characters and underscore "
-                f"allowed in metadata name"
+                f"allowed in metadata name."
             )
             metadata.store_validation_issue(
                 "error", msg, "format:cap:only-alphanumeric-underscore"
@@ -1389,7 +1389,7 @@ def detect_excel_drag(metadata, convention):
                             set(zip(property_ids, property_labels))
                         )
                         if multiply_assigned:
-                            msg += f"Check for mismatches between ontology ID and provided ontology label(s) {multiply_assigned}\n"
+                            msg += f"Check for mismatches between ontology ID and provided ontology label(s) {multiply_assigned}.\n"
                     metadata.store_validation_issue(
                         "error", msg, "ontology:multiply-assigned-label"
                     )
@@ -1444,7 +1444,7 @@ def push_metadata_to_bq(metadata, ndjson, dataset, table):
         dev_logger.exception(e)
         return 1
     if job.output_rows != len(metadata.cells):
-        msg = f"BigQuery upload error: upload ({job.output_rows} rows) does not match number of cells in file, {len(metadata.cells)} cells"
+        msg = f"BigQuery upload error: upload ({job.output_rows} rows) does not match number of cells in file, {len(metadata.cells)} cells."
         print(msg)
         dev_logger.error(msg)
         return 1

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -1221,10 +1221,10 @@ def validate_collected_ontology_data(metadata, convention):
                                 (ontology_id, ontology_label)
                             ],
                         )
-            except ValueError as valueError:
+            except ValueError as value_error:
                 metadata.store_validation_issue(
                     "error",
-                    valueError.args[0],
+                    value_error.args[0],
                     "ontology:label-lookup-error",
                     associated_info=metadata.ontology[property_name][
                         (ontology_id, ontology_label)
@@ -1414,9 +1414,9 @@ def detect_excel_drag(metadata, convention):
                         "error", msg, "ontology:multiply-assigned-label"
                     )
                     dev_logger.exception(msg)
-            except ValueError as valueError:
+            except ValueError as value_error:
                 metadata.store_validation_issue(
-                    "error", valueError.args[0], "ontology:label-lookup-error"
+                    "error", value_error.args[0], "ontology:label-lookup-error"
                 )
 
     return excel_drag

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -1240,7 +1240,7 @@ def validate_collected_ontology_data(metadata, convention):
                     issue_type="runtime",
                 ),
                 # immediately return as validation cannot continue
-                return
+                return None
 
     return
 

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -281,22 +281,22 @@ class OntologyRetriever:
                 labels["synonyms"] = list(set(synonyms))
                 return labels
             else:
-                error_msg = f"{property_name}: No match found in EBI OLS for provided ontology ID: {term}"
-                raise ValueError(error_msg)
+                msg = f"{property_name}: No match found in EBI OLS for provided ontology ID: {term}"
+                raise ValueError(msg)
         elif not metadata_ontology:
-            error_msg = f'No result from EBI OLS for provided ontology shortname "{ontology_shortname}"'
-            print(error_msg)
-            user_logger.error(error_msg)
+            msg = f'No result from EBI OLS for provided ontology shortname "{ontology_shortname}"'
+            print(msg)
+            user_logger.error(msg)
             raise ValueError(
                 f"{property_name}: No match found in EBI OLS for provided ontology ID: {term}"
             )
         else:
-            error_msg = (
+            msg = (
                 f"encountered issue retrieving {ontology_urls} or {ontology_shortname}"
             )
-            print(error_msg)
-            user_logger.info(error_msg)
-            raise RuntimeError(error_msg)
+            print(msg)
+            user_logger.info(msg)
+            raise RuntimeError(msg)
 
     def retrieve_mouse_brain_term(self, term, property_name):
         """Determine whether ID is in mouse brain atlas (MBA) file
@@ -332,8 +332,8 @@ def parse_organ_region_ontology_id(term):
             # remove leading zeroes (e.g. '000786' => '786') since the dictionary file doesn't have them
             return term_id.lstrip("0")
         else:
-            error_msg = f'organ_region: Invalid ontology code, "{ontology_shortname}"'
-            raise ValueError(error_msg)
+            msg = f'organ_region: Invalid ontology code, "{ontology_shortname}"'
+            raise ValueError(msg)
     except (TypeError, ValueError):
         # when term value is empty string -> TypeError, convert this to a value error
         raise ValueError(
@@ -354,9 +354,9 @@ def fetch_allen_mouse_brain_atlas_remote():
         return region_dict
     # if we can't get the file in GitHub for validation record error
     except:  # noqa E722
-        error_msg = "Unable to read GitHub-hosted organ_region ontology file"
-        dev_logger.exception(error_msg)
-        raise RuntimeError(error_msg)
+        msg = "Unable to read GitHub-hosted organ_region ontology file"
+        dev_logger.exception(msg)
+        raise RuntimeError(msg)
 
 
 # Attach exponential backoff to external HTTP requests
@@ -417,9 +417,9 @@ def validate_schema(json, metadata):
         valid_schema = jsonschema.Draft7Validator(json)
         return valid_schema
     except jsonschema.SchemaError:
-        error_msg = "Invalid metadata convention file, cannot validate metadata."
+        msg = "Invalid metadata convention file, cannot validate metadata."
         metadata.store_validation_issue(
-            "error", error_msg, "runtime:invalid-convention", issue_type="runtime"
+            "error", msg, "runtime:invalid-convention", issue_type="runtime"
         )
         return None
 
@@ -493,12 +493,9 @@ def validate_cells_unique(metadata):
         valid = True
     else:
         dups = list_duplicates(metadata.cells)
-        error_msg = "Duplicate CellID(s) in metadata file"
+        msg = "Duplicate CellID(s) in metadata file"
         metadata.store_validation_issue(
-            "error",
-            error_msg,
-            "content:duplicate:cells-within-file",
-            associated_info=dups,
+            "error", msg, "content:duplicate:cells-within-file", associated_info=dups
         )
     return valid
 
@@ -509,12 +506,9 @@ def insert_array_ontology_label_row_data(
     cell_id = row["CellID"]
     # if there are differing numbers of id/label values, and not empty, log error and don't try to fix
     if len(row[property_name]) != len(row[ontology_label]) and row[ontology_label]:
-        error_msg = f"{property_name}: mismatched # of {property_name} and {ontology_label} values"
+        msg = f"{property_name}: mismatched # of {property_name} and {ontology_label} values"
         metadata.store_validation_issue(
-            "error",
-            error_msg,
-            "ontology:array-length-mismatch",
-            associated_info=[cell_id],
+            "error", msg, "ontology:array-length-mismatch", associated_info=[cell_id]
         )
         return row
 
@@ -535,26 +529,26 @@ def insert_array_ontology_label_row_data(
                     if property_name != "organ_region"
                     else "Mouse Brain Atlas ontology"
                 )
-                error_msg = (
+                msg = (
                     f"{property_name}: missing ontology label "
                     f'"{id}" - using "{label_lookup}" per {reference_ontology}'
                 )
                 metadata.store_validation_issue(
                     "warn",
-                    error_msg,
+                    msg,
                     "ontology:missing-label-lookup",
                     associated_info=[cell_id],
                 )
             except BaseException as e:
                 print(e)
-                error_msg = (
+                msg = (
                     f'{property_name}: unable to lookup "{id}" - '
                     f"cannot propagate array of labels for {property_name};"
                     f"may cause inaccurate error reporting for {property_name}"
                 )
                 metadata.store_validation_issue(
                     "error",
-                    error_msg,
+                    msg,
                     "ontology:label-lookup-error",
                     associated_info=[cell_id],
                 )
@@ -591,24 +585,18 @@ def insert_ontology_label_row_data(
                 if property_name != "organ_region"
                 else "Mouse Brain Atlas ontology"
             )
-            error_msg = (
+            msg = (
                 f"{property_name}: missing ontology label "
                 f'"{id}" - using "{label}" per {reference_ontology}'
             )
             metadata.store_validation_issue(
-                "warn",
-                error_msg,
-                "ontology:missing-label-lookup",
-                associated_info=[cell_id],
+                "warn", msg, "ontology:missing-label-lookup", associated_info=[cell_id]
             )
         except BaseException as e:
             print(e)
-            error_msg = f"Optional column {ontology_label} empty and could not be resolved from {property_name} column value {row[property_name]}"
+            msg = f"Optional column {ontology_label} empty and could not be resolved from {property_name} column value {row[property_name]}"
             metadata.store_validation_issue(
-                "warn",
-                error_msg,
-                "ontology:label-lookup-error",
-                associated_info=[cell_id],
+                "warn", msg, "ontology:label-lookup-error", associated_info=[cell_id]
             )
     else:
         metadata.ordered_ontology[property_name].append(id)
@@ -747,12 +735,12 @@ def compare_type_annots_to_convention(metadata, convention):
                 for k, v in annot_equivalents.items():
                     if convention_type in v:
                         expected = k
-                error_msg = (
+                msg = (
                     f'{metadatum}: "{annot}" annotation in metadata file conflicts with metadata convention. '
                     f'Convention expects "{expected}" values.'
                 )
                 metadata.store_validation_issue(
-                    "error", error_msg, "content:type:value-type-mismatch"
+                    "error", msg, "content:type:value-type-mismatch"
                 )
         except TypeError:
             for k, v in annot_equivalents.items():
@@ -765,17 +753,17 @@ def compare_type_annots_to_convention(metadata, convention):
             elif "Unnamed" in annot:
                 # missing type annotation also detected in validate_against_header_count
                 # invalid type annotation is side effect of Pandas
-                error_msg = (
+                msg = (
                     f"{metadatum}: missing TYPE annotation in metadata file. "
                     f'Convention expects "{expected}" annotation.'
                 )
-                metadata.store_validation_issue("error", error_msg, "format:cap:type")
+                metadata.store_validation_issue("error", msg, "format:cap:type")
             else:
-                error_msg = (
+                msg = (
                     f'{metadatum}: invalid "{annot}" annotation in metadata file. '
                     f'Convention expects "{expected}" annotation.'
                 )
-                metadata.store_validation_issue("error", error_msg, "format:cap:type")
+                metadata.store_validation_issue("error", msg, "format:cap:type")
 
 
 def cast_boolean_type(value):
@@ -895,13 +883,13 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
                 cast_values.append(cast_element)
             cast_metadata[metadatum] = cast_values
         except ValueError:
-            error_msg = (
+            msg = (
                 f"{metadatum}: '{element}' in '{value}' does not match "
                 f"expected '{lookup_metadata_type(convention, metadatum)}' type"
             )
             metadata.store_validation_issue(
                 "error",
-                error_msg,
+                msg,
                 "content:type:value-type-mismatch",
                 associated_info=[id_for_error_detail],
             )
@@ -933,10 +921,10 @@ def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metada
             )(value)
             cast_metadata[metadatum] = cast_value
         except ValueError:
-            error_msg = f'{metadatum}: "{value}" does not match expected type'
+            msg = f'{metadatum}: "{value}" does not match expected type'
             metadata.store_validation_issue(
                 "error",
-                error_msg,
+                msg,
                 "content:type:value-type-mismatch",
                 associated_info=[id_for_error_detail],
             )
@@ -1196,26 +1184,26 @@ def validate_collected_ontology_data(metadata, convention):
                     if is_required_metadata(convention, property_name) and (
                         not ontology_label or value_is_nan(ontology_label)
                     ):
-                        error_msg = (
+                        msg = (
                             f'{property_name}: ontology label required for "{ontology_id}" '
                             f'to cross-check for data entry error"'
                         )
                         metadata.store_validation_issue(
                             "error",
-                            error_msg,
+                            msg,
                             "content:missing-required-values",
                             associated_info=metadata.ontology[property_name][
                                 (ontology_id, ontology_label)
                             ],
                         )
                     else:
-                        error_msg = (
+                        msg = (
                             f'{property_name}: input ontology_label "{ontology_label}" '
                             f'does not match {ontology_source_name} lookup "{matched_label_for_id}" for ontology id "{ontology_id}"'
                         )
                         metadata.store_validation_issue(
                             "error",
-                            error_msg,
+                            msg,
                             "ontology:label-not-match-id",
                             associated_info=metadata.ontology[property_name][
                                 (ontology_id, ontology_label)
@@ -1231,13 +1219,10 @@ def validate_collected_ontology_data(metadata, convention):
                     ],
                 )
             except requests.exceptions.RequestException as err:
-                error_msg = f"External service outage connecting to {ontology_urls} when querying {ontology_id}:{ontology_label}: {err}"
-                dev_logger.exception(error_msg)
+                msg = f"External service outage connecting to {ontology_urls} when querying {ontology_id}:{ontology_label}: {err}"
+                dev_logger.exception(msg)
                 metadata.store_validation_issue(
-                    "error",
-                    error_msg,
-                    "runtime:request-exception",
-                    issue_type="runtime",
+                    "error", msg, "runtime:request-exception", issue_type="runtime"
                 ),
                 # immediately return as validation cannot continue
                 return None
@@ -1255,12 +1240,8 @@ def confirm_uniform_units(metadata, convention):
             # existence of unit metadata is enforced by jsonschema
             # any empty cells in a unit column are okay to be empty
             if metadata.file[name].nunique(dropna=True).values[0] != 1:
-                error_msg = (
-                    f"{name}: values for each unit metadata required to be uniform"
-                )
-                metadata.store_validation_issue(
-                    "error", error_msg, "content:uniform-units"
-                )
+                msg = f"{name}: values for each unit metadata required to be uniform"
+                metadata.store_validation_issue("error", msg, "content:uniform-units")
 
 
 def serialize_bq(bq_dict, filename="bq.json"):
@@ -1309,12 +1290,12 @@ def review_metadata_names(metadata):
     for name in metadata_names:
         allowed_char = re.compile("^[A-Za-z0-9_]+$")
         if not allowed_char.match(name):
-            error_msg = (
+            msg = (
                 f"{name}: only alphanumeric characters and underscore "
                 f"allowed in metadata name"
             )
             metadata.store_validation_issue(
-                "error", error_msg, "format:cap:only-alphanumeric-underscore"
+                "error", msg, "format:cap:only-alphanumeric-underscore"
             )
 
 
@@ -1464,9 +1445,9 @@ def push_metadata_to_bq(metadata, ndjson, dataset, table):
         dev_logger.exception(e)
         return 1
     if job.output_rows != len(metadata.cells):
-        error_msg = f"BigQuery upload error: upload ({job.output_rows} rows) does not match number of cells in file, {len(metadata.cells)} cells"
-        print(error_msg)
-        dev_logger.error(error_msg)
+        msg = f"BigQuery upload error: upload ({job.output_rows} rows) does not match number of cells in file, {len(metadata.cells)} cells"
+        print(msg)
+        dev_logger.error(msg)
         return 1
     os.remove(ndjson)
     return 0

--- a/tests/test_dense.py
+++ b/tests/test_dense.py
@@ -137,8 +137,8 @@ class TestDense(unittest.TestCase):
             DenseIngestor.filter_expression_scores(too_many_scores, cells)
         expected_msg = (
             "Number of cell and expression values must be the same. "
-            f"Found row with {len(too_many_scores)} expression values."
-            f"Header contains {len(cells)} cells"
+            f"Found row with {len(too_many_scores)} expression values. "
+            f"Header contains {len(cells)} cells."
         )
         self.assertEqual(expected_msg, str(error.exception))
 
@@ -231,7 +231,7 @@ class TestDense(unittest.TestCase):
                 ["GENE", "foo", "foo"], ["gene1", "0", "1"], query_params
             )
         expected_msg = (
-            "Duplicate header values are not allowed. Duplicates include: \"foo\""
+            'Duplicate header values are not allowed. Duplicates include: "foo"'
         )
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -239,7 +239,7 @@ class TestDense(unittest.TestCase):
         mock_check_unique_cells.return_value = True
         with self.assertRaises(ValueError) as cm:
             DenseIngestor.check_valid(["foo", "nan"], ["foo2", "foo3"], query_params)
-        expected_msg = "Required \"GENE\" header is not present; \"nan\" is not allowed as a header value"
+        expected_msg = 'Required "GENE" header is not present.; "nan" is not allowed as a header value.'
         self.assertEqual(expected_msg, str(cm.exception))
 
     @patch("expression_files.expression_files.GeneExpression.load")

--- a/tests/test_dense.py
+++ b/tests/test_dense.py
@@ -230,14 +230,16 @@ class TestDense(unittest.TestCase):
             DenseIngestor.check_valid(
                 ["GENE", "foo", "foo"], ["gene1", "0", "1"], query_params
             )
-        expected_msg = "Duplicate header values are not allowed"
+        expected_msg = (
+            "Duplicate header values are not allowed. Duplicates include: \"foo\""
+        )
         self.assertEqual(expected_msg, str(cm.exception))
 
         # Should concatenate the two value errors
         mock_check_unique_cells.return_value = True
         with self.assertRaises(ValueError) as cm:
             DenseIngestor.check_valid(["foo", "nan"], ["foo2", "foo3"], query_params)
-        expected_msg = "Required 'GENE' header is not present; nan is not allowed as a header value"
+        expected_msg = "Required \"GENE\" header is not present; \"nan\" is not allowed as a header value"
         self.assertEqual(expected_msg, str(cm.exception))
 
     @patch("expression_files.expression_files.GeneExpression.load")

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -19,35 +19,24 @@ def mock_post_event(props):
     update_user_id = True if MetricProperties.USER_ID in props else False
 
     props = json.loads(props)
+    expected_props = {
+        "properties": {
+            "studyAccession": "SCP123",
+            "fileName": "File_name.txt",
+            "fileType": "Expression matrix",
+            "fileSize": 400,
+            "trigger": "upload",
+            "logger": "ingest-pipeline",
+            "appId": "single-cell-portal",
+            "status": "success",
+        }
+    }
     if props["event"] == "file-validation":
-        expected_props = {
-            "event": "file-validation",
-            "properties": {
-                "studyAccession": "SCP123",
-                "fileName": "File_name.txt",
-                "fileType": "Expression matrix",
-                "fileSize": 400,
-                "trigger": "upload",
-                "logger": "ingest-pipeline",
-                "appId": "single-cell-portal",
-                "status": "success",
-            },
-        }
+        expected_props["event"] = "file-validation"
     else:
-        expected_props = {
-            "event": "ingest-pipeline:expression:ingest",
-            "properties": {
-                "studyAccession": "SCP123",
-                "fileName": "File_name.txt",
-                "fileType": "Expression matrix",
-                "fileSize": 400,
-                "trigger": "upload",
-                "logger": "ingest-pipeline",
-                "appId": "single-cell-portal",
-                "functionName": "ingest_expression",
-                "status": "success",
-            },
-        }
+        expected_props["event"] = "ingest-pipeline:expression:ingest"
+        expected_props["properties"]["functionName"] = "ingest_expression"
+    # delete perfTime as that value is variable and cannot be expected
     if props["properties"].get("perfTime"):
         del props["properties"]["perfTime"]
     if update_user_id:

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -25,7 +25,7 @@ def mock_post_event(props):
             "fileName": "File_name.txt",
             "fileType": "Expression matrix",
             "fileSize": 400,
-            "trigger": "upload",
+            "trigger": "not set",
             "logger": "ingest-pipeline",
             "appId": "single-cell-portal",
             "status": "success",

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -15,26 +15,45 @@ user_metrics_uuid = "123e4567-e89b-12d3-a456-426614174000"
 
 # Mocked function that replaces MetricsService.post_event
 def mock_post_event(props):
-    expected_props = {
-        "event": "ingest-pipeline:expression:ingest",
-        "properties": {
-            "studyAccession": "SCP123",
-            "fileName": "File_name.txt",
-            "fileType": "Expression matrix",
-            "fileSize": 400,
-            "trigger": "upload",
-            "logger": "ingest-pipeline",
-            "appId": "single-cell-portal",
-            "functionName": "ingest_expression",
-        },
-    }
+    # detect user uuid state before serializing props
+    update_user_id = True if MetricProperties.USER_ID in props else False
 
-    if MetricProperties.USER_ID in props:
+    props = json.loads(props)
+    if props["event"] == "file-validation":
+        expected_props = {
+            "event": "file-validation",
+            "properties": {
+                "studyAccession": "SCP123",
+                "fileName": "File_name.txt",
+                "fileType": "Expression matrix",
+                "fileSize": 400,
+                "trigger": "upload",
+                "logger": "ingest-pipeline",
+                "appId": "single-cell-portal",
+                "status": "success",
+            },
+        }
+    else:
+        expected_props = {
+            "event": "ingest-pipeline:expression:ingest",
+            "properties": {
+                "studyAccession": "SCP123",
+                "fileName": "File_name.txt",
+                "fileType": "Expression matrix",
+                "fileSize": 400,
+                "trigger": "upload",
+                "logger": "ingest-pipeline",
+                "appId": "single-cell-portal",
+                "functionName": "ingest_expression",
+                "status": "success",
+            },
+        }
+    if props["properties"].get("perfTime"):
+        del props["properties"]["perfTime"]
+    if update_user_id:
         expected_props["properties"]["distinct_id"] = MetricProperties.USER_ID
     else:
         expected_props["properties"]["distinct_id"] = user_metrics_uuid
-    props = json.loads(props)
-    del props["properties"]["perfTime"]
     assert props == expected_props
 
 

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -142,7 +142,7 @@ class TestMTXIngestor(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             file_handler = open("data/mtx/no_data.mtx.txt")
             MTXIngestor.get_mtx_dimensions(file_handler)
-        self.assertEqual("MTX file did not contain data", str(cm.exception))
+        self.assertEqual("MTX file did not contain expression data", str(cm.exception))
 
     def test_check_duplicates(self):
 

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -142,7 +142,7 @@ class TestMTXIngestor(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             file_handler = open("data/mtx/no_data.mtx.txt")
             MTXIngestor.get_mtx_dimensions(file_handler)
-        self.assertEqual("MTX file did not contain expression data", str(cm.exception))
+        self.assertEqual("MTX file did not contain expression data.", str(cm.exception))
 
     def test_check_duplicates(self):
 
@@ -175,7 +175,7 @@ class TestMTXIngestor(unittest.TestCase):
 
         expected_dup_msg = (
             "Duplicate values are not allowed. "
-            "There are 1 duplicates in the barcode file"
+            "There are 1 duplicates in the barcode file."
         )
         self.assertEqual(expected_dup_msg, str(cm.exception))
 

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -94,19 +94,19 @@ class TestValidateMetadata(unittest.TestCase):
         # reference errors tests for:
         # incorrectly delimited value in numeric column
         self.assertIn(
-            "disease__time_since_onset: '12,2' in '12,2' does not match expected 'number' type",
+            "disease__time_since_onset: '12,2' in '12,2' does not match expected 'number' type.",
             metadata.issues["error"]["content"].keys(),
             "comma-delimited values for array metadata should fail",
         )
         # incorrectly delimited value in boolean column
         self.assertIn(
-            "disease__treated: 'True,False' in 'True,False' does not match expected 'boolean' type",
+            "disease__treated: 'True,False' in 'True,False' does not match expected 'boolean' type.",
             metadata.issues["error"]["content"].keys(),
             "comma-delimited values for array metadata should fail",
         )
         # partial correctly delimited value in numeric column should still fail
         self.assertIn(
-            "disease__time_since_onset: '3,1' in '36|3,1' does not match expected 'number' type",
+            "disease__time_since_onset: '3,1' in '36|3,1' does not match expected 'number' type.",
             metadata.issues["error"]["content"].keys(),
             "incorrectly delimited values for array metadata should fail",
         )
@@ -458,7 +458,7 @@ class TestValidateMetadata(unittest.TestCase):
         self.assertEqual(
             metadata.issues["error"]["ontology"],
             {
-                "ethnicity: mismatched # of ethnicity and ethnicity__ontology_label values": [
+                "ethnicity: mismatched # of ethnicity and ethnicity__ontology_label values.": [
                     "test1"
                 ]
             },
@@ -502,7 +502,7 @@ class TestValidateMetadata(unittest.TestCase):
         # reference errors tests for:
         #   duplicate CellIDs are not permitted
         self.assertIn(
-            "Duplicate CellID(s) in metadata file",
+            "Duplicate CellID(s) in metadata file.",
             metadata.issues["error"]["content"].keys(),
             "Duplicate CellID(s) in metadata file should result in error",
         )
@@ -527,7 +527,7 @@ class TestValidateMetadata(unittest.TestCase):
         )
         #   value provided not a number for 'organism_age'
         self.assertIn(
-            "organism_age: \"foo\" does not match expected type",
+            "organism_age: \"foo\" does not match expected type.",
             metadata.issues["error"]["content"].keys(),
             "ontology_label without ontology ID data results in error, even for non-required metadata",
         )
@@ -606,7 +606,7 @@ class TestValidateMetadata(unittest.TestCase):
         #   invalid ontology label 'homo sapien' for species__ontology_label
         #     with species ontologyID of 'NCBITaxon_9606'
         self.assertIn(
-            'species: input ontology_label "homo sapien" does not match EBI OLS lookup "Homo sapiens" for ontology id "NCBITaxon_9606"',
+            'species: input ontology_label "homo sapien" does not match EBI OLS lookup "Homo sapiens" for ontology id "NCBITaxon_9606".',
             metadata.issues["error"]["ontology"].keys(),
         )
         #   invalid ontologyID 'NCBITaxon_9606' for geographical_region
@@ -683,29 +683,29 @@ class TestValidateMetadata(unittest.TestCase):
         )
         # invalid array-based metadata type: disease__time_since_onset
         self.assertIn(
-            "disease__time_since_onset: 'three' in '36|three|1' does not match expected 'number' type",
+            "disease__time_since_onset: 'three' in '36|three|1' does not match expected 'number' type.",
             metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         self.assertIn(
-            "disease__time_since_onset: 'zero' in 'zero' does not match expected 'number' type",
+            "disease__time_since_onset: 'zero' in 'zero' does not match expected 'number' type.",
             metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         # invalid boolean value: disease__treated
         self.assertIn(
-            "disease__treated: 'T' in 'T|F' does not match expected 'boolean' type",
+            "disease__treated: 'T' in 'T|F' does not match expected 'boolean' type.",
             metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         self.assertIn(
-            "disease__treated: 'F' in 'F' does not match expected 'boolean' type",
+            "disease__treated: 'F' in 'F' does not match expected 'boolean' type.",
             metadata.issues["error"]["content"].keys(),
             "metadata validation should fail if metadata type does not match convention-designated type",
         )
         # non-uniform unit values: organism_age__unit
         self.assertIn(
-            "disease__time_since_onset__unit: values for each unit metadata required to be uniform",
+            "disease__time_since_onset__unit: values for each unit metadata required to be uniform.",
             metadata.issues["error"]["content"].keys(),
             "Ontology_label values for units should be uniform",
         )
@@ -723,7 +723,7 @@ class TestValidateMetadata(unittest.TestCase):
         )
         # invalid header content: donor info (only alphanumeric or underscore allowed)
         self.assertIn(
-            "donor info: only alphanumeric characters and underscore allowed in metadata name",
+            "donor info: only alphanumeric characters and underscore allowed in metadata name.",
             metadata.issues["error"]["format"].keys(),
             "metadata names must follow header rules (only alphanumeric or underscore allowed)",
         )
@@ -732,17 +732,17 @@ class TestValidateMetadata(unittest.TestCase):
         # Arrays have NA values
         metadata = set_up_test("has_na_in_array.tsv")
         self.assertIn(
-            "disease__time_since_onset: 'None' in 'None' does not match expected 'number' type",
+            "disease__time_since_onset: 'None' in 'None' does not match expected 'number' type.",
             metadata.issues["error"]["content"].keys(),
             "Non-numeric 'None' provided instead of numeric array should fail",
         )
         self.assertIn(
-            "disease__treated: 'N/A' in 'True|N/A|False' does not match expected 'boolean' type",
+            "disease__treated: 'N/A' in 'True|N/A|False' does not match expected 'boolean' type.",
             metadata.issues["error"]["content"].keys(),
             "Non-boolean 'N/A' provided in boolean array should fail",
         )
         self.assertIn(
-            "disease__treated: 'None' in 'FALSE|None' does not match expected 'boolean' type",
+            "disease__treated: 'None' in 'FALSE|None' does not match expected 'boolean' type.",
             metadata.issues["error"]["content"].keys(),
             "Non-boolean 'None' provided in boolean array should fail",
         )
@@ -839,13 +839,13 @@ class TestValidateMetadata(unittest.TestCase):
         )
         #   mismatch of organ_region__ontology_label value with label value in MBA
         self.assertIn(
-            'organ_region: input ontology_label \"Crus 1, urkinje layer\" does not match Allen Mouse Brain Atlas lookup \"Crus 1, Purkinje layer\" for ontology id \"MBA_000010676\"',
+            'organ_region: input ontology_label \"Crus 1, urkinje layer\" does not match Allen Mouse Brain Atlas lookup \"Crus 1, Purkinje layer\" for ontology id \"MBA_000010676\".',
             metadata.issues["error"]["ontology"].keys(),
             "mismatch of organ_region__ontology_label value with label value in MBA should error",
         )
         #   mismatch of organ_region__ontology_label value with label from MBA_id lookup
         self.assertIn(
-            'organ_region: input ontology_label \"Paraflocculus, granular layer\" does not match Allen Mouse Brain Atlas lookup \"Copula pyramidis, molecular layer\" for ontology id \"MBA_000010686\"',
+            'organ_region: input ontology_label \"Paraflocculus, granular layer\" does not match Allen Mouse Brain Atlas lookup \"Copula pyramidis, molecular layer\" for ontology id \"MBA_000010686\".',
             metadata.issues["error"]["ontology"].keys(),
             "mismatch of organ_region__ontology_label value with label from MBA_id lookup should error",
         )
@@ -914,7 +914,7 @@ class TestValidateMetadata(unittest.TestCase):
 
         self.assertEqual(
             list(metadata.issues["error"]["content"].keys())[0],
-            'percent_mt: supplied value 07.juil is not numeric',
+            'percent_mt: supplied value 07.juil is not numeric.',
             "expected error message not generated",
         )
         self.teardown_metadata(metadata)
@@ -980,7 +980,7 @@ class TestValidateMetadata(unittest.TestCase):
             "exiting validation, ontology content not validated against ontology server.\n"
             "Please confirm ontology IDs are correct and resubmit.\n"
             "Check for mismatches between ontology ID and provided ontology label(s) "
-            "['absent', 'disease or disorder']\n",
+            "['absent', 'disease or disorder'].\n",
             metadata.issues["error"]["ontology"].keys(),
             "ontology label multiply paired with IDs should error",
         )


### PR DESCRIPTION
Adding Mixpanel logging to ingest pipeline expression matrix errors. This PR addresses logging of errors from the GeneExpression Class. 

This PR generates a "file-validation" event to mixpanel logging upon completion of an ingest pipeline expression matrix ingest.

Bugfix - with this PR file-validation events should now correctly discriminate between triggers "sync" and "upload"

Logging refinement - with this PR file-validation events will no longer report "errors" or "warnings" (but will continue to report "numErrors" and "numWarnings", where applicable) - this change avoids the loss of logging when the reported errors/warnings are too long and would trigger a Bard error instead of logging to Mixpanel

set your local Portal instance to use docker image:
gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_matrix_mixpanel:58a9a62
	
Test 1: show successful ingest of a sparse matrix using upload wizard

a. upload the following sparse matrix files from the scp-ingest-pipeline repo
tests/data/mtx/matrix.mtx
tests/data/mtx/barcodes.tsv
tests/data/mtx/genes.tsv

b. confirm that the mixpanel file-validation event (in Mixpanel Dev) with 
fileType: MM Coordinate Matrix
logger: ingest-pipeline 
trigger: upload
status: success

Test 2: show logging of failed ingest of a dense matrix using upload wizard

a. gsutil the following dense matrix files from the scp-ingest-pipeline repo
tests/data/expression_matrix_non_unique.txt

b. sync the file as a raw count matrix (or processed matrix) should fail either way

c. confirm that the mixpanel file-validation event (in Mixpanel Dev) with 
confirm that field 'errors' is not reported
errorTypes: ["content:duplicate:cells-within-file"]
numErrors: 1
numErrortypes: 1
fileType: Expression Matrix
logger: ingest-pipeline 
trigger: sync
status: failure

This PR satisfies SCP-4037.