### PR TITLE
Update pip in docker build to resolve pandas install issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get -y update && \
   apt -y install python3.7-dev
 
 RUN python3.7 -m pip install pip
+RUN python3.7 -m pip install --upgrade pip
 
 # Set cleaner defaults (`alias` fails)
 RUN ln -s /usr/bin/python3.7 /usr/bin/python && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get -y update && \
   apt -y install python3.7 && \
   apt -y install python3.7-dev
 
-RUN python3.7 -m pip install pip
 RUN python3.7 -m pip install --upgrade pip
 
 # Set cleaner defaults (`alias` fails)


### PR DESCRIPTION
The update of pandas in `jlc_make_data_objects` caused a cloud build failure because more recent pandas' setup.py invoke `import numpy`. In a cloud build scenario, numpy is collected but not installed when the pandas build is attempted so the pandas build fails (Older pip builds each package first before installing any packages). 
<img width="827" alt="Screen Shot 2022-03-28 at 11 48 50 AM" src="https://user-images.githubusercontent.com/6005195/160448640-e5c6cecc-0d8a-4f7f-999f-cfa504b95322.png">

By updating pip as part of the docker install process, a more sophisticated install solver uses better order of installation to ensure numpy is available before pandas installation is attempted.

![Screen Shot 2022-03-28 at 12 48 22 PM](https://user-images.githubusercontent.com/6005195/160447847-d471a673-96b0-4997-85a8-abe64b889ec3.png)

