### PR TITLE
Update CircleCI configs to skip problematic tests (SCP-4209)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/python:3.7.5
+      - image: circleci/python:3.7.5-stretch
 
     working_directory: ~/scp-ingest-pipeline
 
@@ -24,13 +24,10 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v3-dependencies-
 
-      # unable to install tabix with base image cimg/python:3.7.5
-      # commenting out install because also no longer running test_genomes
-      # if restoring test_genomes, will need to resolve tabix install issue
-      # - run:
-      #     name: Install system dependencies for Genomes Pipeline
-      #     command: |
-      #       sudo apt-get install -y tabix
+      - run:
+          name: Install system dependencies for Genomes Pipeline
+          command: |
+            sudo apt-get install -y tabix
 
       - run:
           name: Install Python dependencies
@@ -50,7 +47,7 @@ jobs:
           command: |
             . venv/bin/activate
             cd tests
-            pytest -vv -k 'not test_genomes and not test_make_toy' --cov-report=xml --cov=../ingest/
+            pytest --cov-report=xml --cov=../ingest/
 
       - codecov/upload:
           file: tests/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - checkout
 
-      Download and cache dependencies
+      # Download and cache dependencies
       - restore_cache:
           keys:
             - v3-dependencies-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
           name: Install Python dependencies
           command: |
             ls -l /home/circleci/scp-ingest-pipeline/venv/bin/python3
-            ls -l /usr/local/bin/python3
             ls -l /home/circleci/.pyenv/shims/python3
             python3 -m venv venv
             echo "did venv"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           command: |
             . venv/bin/activate
             cd tests
-            pytest --cov-report=xml --cov=../ingest/
+            pytest -k 'not test_genomes and not test_make_toy' --cov-report=xml --cov=../ingest/
 
       - codecov/upload:
           file: tests/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: |
             python --version
             pwd
-            ls
+            ls -l venv/bin
             python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.5-stretch
+      - image: cimg/python:3.7.5
 
     working_directory: ~/scp-ingest-pipeline
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,13 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v3-dependencies-
 
-      - run:
-          name: Install system dependencies for Genomes Pipeline
-          command: |
-            sudo apt-get install -y tabix
+      # unable to install tabix with base image cimg/python:3.7.5
+      # commenting out install because also no longer running test_genomes
+      # if restoring test_genomes, will need to resolve tabix install issue
+      # - run:
+      #     name: Install system dependencies for Genomes Pipeline
+      #     command: |
+      #       sudo apt-get install -y tabix
 
       - run:
           name: Install Python dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            pyenv local 3.7.5
+            ls -l /home/circleci/scp-ingest-pipeline/venv/bin/python3
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            which python
+            python --version
+            pwd
+            ls
             python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,7 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            pyenv versions
-            pyenv install --list
-            which python
-            which python3
+            pyenv local 3.7.5
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ jobs:
           command: |
             ls -l /home/circleci/scp-ingest-pipeline/venv/bin/python3
             ls -l /home/circleci/.pyenv/shims/python3
-            python3 -m venv venv
+            /home/circleci/.pyenv/shims/python3 --version
+            /home/circleci/.pyenv/shims/python3 -m venv venv
             echo "did venv"
             . venv/bin/activate
             echo "sourced venv"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,12 @@ jobs:
           name: Install Python dependencies
           command: |
             ls -l /home/circleci/scp-ingest-pipeline/venv/bin/python3
+            ls -l /usr/local/bin/python3
+            ls -l /home/circleci/.pyenv/shims/python3
             python3 -m venv venv
+            echo "did venv"
             . venv/bin/activate
+            echo "sourced venv"
             pip install --upgrade pip
             pip install -r requirements.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,11 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            /usr/local/bin/python3 -m venv venv
+            pyenv versions
+            pyenv install --list
+            which python
+            which python3
+            python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - checkout
 
-      # Download and cache dependencies
-      # - restore_cache:
-      #     keys:
-      #       - v3-dependencies-{{ checksum "requirements.txt" }}
-      #       # fallback to using the latest cache if no exact match is found
-      #       - v3-dependencies-
+      Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v3-dependencies-{{ checksum "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v3-dependencies-
 
       # unable to install tabix with base image cimg/python:3.7.5
       # commenting out install because also no longer running test_genomes
@@ -50,7 +50,7 @@ jobs:
           command: |
             . venv/bin/activate
             cd tests
-            pytest -k 'not test_genomes and not test_make_toy' --cov-report=xml --cov=../ingest/
+            pytest -vv -k 'not test_genomes and not test_make_toy' --cov-report=xml --cov=../ingest/
 
       - codecov/upload:
           file: tests/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ jobs:
       - checkout
 
       # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v3-dependencies-
+      # - restore_cache:
+      #     keys:
+      #       - v3-dependencies-{{ checksum "requirements.txt" }}
+      #       # fallback to using the latest cache if no exact match is found
+      #       - v3-dependencies-
 
       # unable to install tabix with base image cimg/python:3.7.5
       # commenting out install because also no longer running test_genomes
@@ -35,13 +35,8 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            ls -l /home/circleci/scp-ingest-pipeline/venv/bin/python3
-            ls -l /home/circleci/.pyenv/shims/python3
-            /home/circleci/.pyenv/shims/python3 --version
-            /home/circleci/.pyenv/shims/python3 -m venv venv
-            echo "did venv"
+            python3 -m venv venv
             . venv/bin/activate
-            echo "sourced venv"
             pip install --upgrade pip
             pip install -r requirements.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            python3 -m venv venv
+            which python
+            python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,7 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            python --version
-            pwd
-            ls -l venv/bin
-            python -m venv venv
+            /usr/local/bin/python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt


### PR DESCRIPTION
test_make_toy and test_genomes reach out to NCBI and/or Ensembl. These external dependencies have lead to false positives in CI testing which slows down the development cycle. Because the functionality being testing is not used in production, let's skip these tests in CI but retain them in the codebase for internal reference.

locally, in the tests directory, you can run:
pytest -k 'not test_genomes and not test_make_toy' 
and confirm that test_make_toy and test_genomes are no longer run.

Confirm the behavior in CircleCI for the following CI runs in the `Run tests` section:
https://app.circleci.com/pipelines/github/broadinstitute/scp-ingest-pipeline/1518/workflows/98ec5329-5d4e-4721-881b-988da1b145e1/jobs/1472
https://app.circleci.com/pipelines/github/broadinstitute/scp-ingest-pipeline/1518/workflows/98ec5329-5d4e-4721-881b-988da1b145e1/jobs/1490
The end of the section indicates "=========== 122 passed, 2 deselected" 

The two deselected are test_make_toy and test_genomes, which you can confirm by scrolling up to the top of the section and confirm that neither shows up in the "test session starts" section (above the warnings summary section).

This satisfies SCP-4209