### PR TITLE
Integration test for pilot DE process (SCP-4204)

### DIFF
--- a/ingest/de.py
+++ b/ingest/de.py
@@ -159,7 +159,7 @@ class DifferentialExpression:
                 self.barcodes,
             )
             DifferentialExpression.de_logger.info("preparing DE on sparse matrix")
-        else:
+        elif self.matrix_file_type == "dense":
             self.run_h5ad(
                 self.cluster,
                 self.metadata,
@@ -171,6 +171,12 @@ class DifferentialExpression:
                 self.method,
             )
             DifferentialExpression.de_logger.info("preparing DE on dense matrix")
+        else:
+            msg = f"Submitted matrix_file_type should be 'dense' or 'mtx' not {self.matrix_file_type}"
+            log_exception(
+                DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
+            )
+            raise ValueError(msg)
 
     @staticmethod
     def run_h5ad(

--- a/ingest/de.py
+++ b/ingest/de.py
@@ -172,7 +172,7 @@ class DifferentialExpression:
             )
             DifferentialExpression.de_logger.info("preparing DE on dense matrix")
         else:
-            msg = f"Submitted matrix_file_type should be 'dense' or 'mtx' not {self.matrix_file_type}"
+            msg = f"Submitted matrix_file_type should be \"dense\" or \"mtx\" not {self.matrix_file_type}"
             log_exception(
                 DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
             )

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -1,0 +1,64 @@
+""" test_de.py
+    integration test to verify that de process generates expected output
+"""
+
+import unittest
+import sys
+import hashlib
+
+sys.path.append("../ingest")
+from cell_metadata import CellMetadata
+from clusters import Clusters
+from de import DifferentialExpression
+
+
+class TestDifferentialExpression(unittest.TestCase):
+    def test_de_process(self):
+        """ Run DE on small test case
+            confirm expected output
+        """
+        cm = CellMetadata(
+            "../tests/data/differential_expression/de_integration_unordered_metadata.tsv",
+            "addedfeed000000000000000",
+            "dec0dedfeed0000000000000",
+            study_accession="SCPde",
+            tracer=None,
+        )
+
+        cluster = Clusters(
+            "../tests/data/differential_expression/de_integration_cluster.tsv",
+            "addedfeed000000000000000",
+            "dec0dedfeed0000000000000",
+            "de_integration",
+        )
+
+        de_kwargs = {
+            "study_accession": cm.study_accession,
+            "name": cluster.name,
+            "method": "wilcoxon",
+        }
+
+        de = DifferentialExpression(
+            cluster,
+            cm,
+            "../tests/data/differential_expression/de_integration.tsv",
+            "dense",
+            "cell_type__ontology_label",
+            **de_kwargs,
+        )
+        de.execute_de()
+
+        expected_checksum = "e3cc75eb3226ec8a2198205bc3e4581e"
+
+        with open(
+            "../tests/de_integration--cell_type__ontology_label--cholinergic_neuron--wilcoxon.tsv",
+            "rb",
+        ) as f:
+            bytes = f.read()
+            de_output_checksum = hashlib.md5(bytes).hexdigest()
+        self.assertEqual(
+            de_output_checksum,
+            expected_checksum,
+            "generated output file should match expected checksum",
+        )
+

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -48,8 +48,10 @@ class TestDifferentialExpression(unittest.TestCase):
         )
         de.execute_de()
 
+        # md5 checksum calculated using reference file in tests/data/differential_expression/reference
         expected_checksum = "e3cc75eb3226ec8a2198205bc3e4581e"
 
+        # running DifferentialExpression via pytest results in output files in the tests dir
         with open(
             "../tests/de_integration--cell_type__ontology_label--cholinergic_neuron--wilcoxon.tsv",
             "rb",


### PR DESCRIPTION
Using a small test dataset derived from public study SCP1677, implemented an integration test for the pilot DE pipeline. This test runs the equivalent of:

> ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed0000000000000 differential_expression --annotation cell_type__ontology_label --matrix-file-path ../tests/data/differential_expression/de_integration.tsv --matrix-file-type dense --cell-metadata-file ../tests/data/differential_expression/de_integration_unordered_metadata.tsv --cluster-file ../tests/data/differential_expression/de_integration_cluster.tsv --name de_integration --study-accession SCPde --differential_expression 

and checks that expected output file "de_integration--cell_type__ontology_label--cholinergic_neuron--wilcoxon.tsv"
has the same md5 checksum as the checksum calculated using the reference file in `tests/data/differential_expression/reference`

To test locally, in the test directory, run:
pytest -k test_de_process
and confirm that it passes.

This satisfies SCP-4204.
