### PR TITLE
Fix ingest pipeline user_log.txt delocalization (SCP-4445)

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -580,12 +580,13 @@ def exit_pipeline(ingest, status, status_cell_metadata, arguments):
                     study_file_id, arguments["study_id"], file_path, "log.txt", log_path
                 )
                 # Delocalize user log
+                user_log_path = f"parse_logs/{study_file_id}/user_log.txt"
                 IngestFiles.delocalize_file(
                     study_file_id,
                     arguments["study_id"],
                     file_path,
                     "user_log.txt",
-                    log_path,
+                    user_log_path,
                 )
             if status_cell_metadata is not None:
                 if status_cell_metadata > 0 and ingest.cell_metadata.is_remote_file:


### PR DESCRIPTION
Modifying ingest pipeline file delocalization for DE introduced a bug that causes the user_log.txt to no longer be available. Study owners are not receiving the necessary information to correct their files.

This PR restores user_log.txt delocalization so ingest errors can be delivered to study owners.

To test:

1. Start up your local instance with DelayedJob.

2. In your local instance, make sure `QA Dev Email` is set to your email address so you will receive admin notification emails for local ingest jobs.

3. Set `Ingest Pipeline Docker Image` to:
gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_fix_delocalization:f67e490

4. From ingest repo, upload `scp-ingest-pipeline/tests/data/annotation/metadata/invalid_metadata_v2.0.0.tsv` as metadata file

5. Find the following email notifications and confirm expected content

 **[Single Cell Portal Notifier] Error: Metadata file: 'invalid_mba_v2.1.2.tsv' parse has failed**

> Errors
> 
> *** convention error list:
> 'organ_region' is a dependency of 'organ_region__ontology_label' [ Error count: 1 ]
> 
> *** ontology error list:
> organ_region: No match found in Allen Mouse Brain Atlas for provided ontology ID: MBA_999999999 [ Error count: 1 ]
> organ_region: input ontology_label "Crus 1, urkinje layer" does not match Allen Mouse Brain Atlas lookup "Crus 1, Purkinje layer" for ontology id "MBA_000010676". [ Error count: 1 ]
> organ_region: input ontology_label "Paraflocculus, granular layer" does not match Allen Mouse Brain Atlas lookup "Copula pyramidis, molecular layer" for ontology id "MBA_000010686". [ Error count: 1 ]
> 

**[Single Cell Portal Admin Notification] Error: Metadata file: 'invalid_mba_v2.1.2.tsv' parse has failed**

> Errors
> 2022-06-14T13:05:13+0000 ingest_files INFO:gs://fc-f16884df-ee7b-4a92-917f-6a2901b13694/invalid_mba_v2.1.2.tsv downloaded to /tmp/invalid_mba_v2.1.2.tsv.
> 2022-06-14T13:05:13+0000 ingest_files INFO:Opening /tmp/invalid_mba_v2.1.2.tsv as: text/tab-separated-values
> 2022-06-14T13:05:13+0000 ingest_files INFO:gs://fc-f16884df-ee7b-4a92-917f-6a2901b13694/invalid_mba_v2.1.2.tsv downloaded to /tmp/invalid_mba_v2.1.2.tsv.
> 2022-06-14T13:05:13+0000 ingest_files INFO:Opening /tmp/invalid_mba_v2.1.2.tsv as: text/tab-separated-values
> 2022-06-14T13:05:13+0000 __main__ INFO:Cell metadata file format valid
> 2022-06-14T13:05:13+0000 ingest_files INFO:Opening ../schema/alexandria_convention/alexandria_convention_schema.json as: application/json
> 2022-06-14T13:05:13+0000 validation.validate_metadata INFO:Checking metadata content against convention rules
> 2022-06-14T13:05:13+0000 validation.validate_metadata INFO:Checking for "Excel drag" events
> 2022-06-14T13:05:13+0000 validation.validate_metadata INFO:Validating ontology content against EBI OLS
> 2022-06-14T13:05:24+0000 validation.validate_metadata INFO:Checking for validation issues
> 2022-06-14T13:05:24+0000 validation.validate_metadata.user_logger ERROR:
> *** convention error list:
> 2022-06-14T13:05:24+0000 validation.validate_metadata.user_logger ERROR:'organ_region' is a dependency of 'organ_region__ontology_label' [ Error count: 1 ]
> 2022-06-14T13:05:24+0000 validation.validate_metadata.user_logger ERROR:
> *** ontology error list:
> 2022-06-14T13:05:24+0000 validation.validate_metadata.user_logger ERROR:organ_region: No match found in Allen Mouse Brain Atlas for provided ontology ID: MBA_999999999 [ Error count: 1 ]
> 2022-06-14T13:05:24+0000 validation.validate_metadata.user_logger ERROR:organ_region: input ontology_label "Crus 1, urkinje layer" does not match Allen Mouse Brain Atlas lookup "Crus 1, Purkinje layer" for ontology id "MBA_000010676". [ Error count: 1 ]
> 2022-06-14T13:05:24+0000 validation.validate_metadata.user_logger ERROR:organ_region: input ontology_label "Paraflocculus, granular layer" does not match Allen Mouse Brain Atlas lookup "Copula pyramidis, molecular layer" for ontology id "MBA_000010686". [ Error count: 1 ]

 
 This PR satisfies SCP-4445.