### PR TITLE
Distinguish between + and - in sanitized DE filenames (SCP-4533)

### DIFF
--- a/ingest/de.py
+++ b/ingest/de.py
@@ -51,8 +51,6 @@ class DifferentialExpression:
         self.kwargs = kwargs
         self.accession = self.kwargs["study_accession"]
         self.annot_scope = self.kwargs["annotation_scope"]
-        # only used in output filename, replacing non-alphanumeric with underscores
-        self.cluster_name = re.sub(r'\W', '_', self.kwargs["name"])
         self.method = self.kwargs["method"]
 
         if matrix_file_type == "mtx":
@@ -183,6 +181,11 @@ class DifferentialExpression:
     def execute_de(self):
         print(f'dev_info: Starting DE for {self.accession}')
         try:
+            # only used in output filename, replacing non-alphanumeric with underscores
+            # except '+' replaced with 'pos'
+            self.cluster_name = DifferentialExpression.sanitize_strings(
+                self.kwargs["name"]
+            )
             if self.matrix_file_type == "mtx":
                 DifferentialExpression.de_logger.info("preparing DE on sparse matrix")
                 self.run_scanpy_de(
@@ -395,8 +398,7 @@ class DifferentialExpression:
             rank = sc.get.rank_genes_groups_df(adata, key=rank_key, group=group)
             if DifferentialExpression.delimiter_in_gene_name(rank):
                 DifferentialExpression.extract_gene_id_for_out_file(rank)
-            cleaned_cluster_name = DifferentialExpression.sanitize_strings(cluster_name)
-            out_file = f'{cleaned_cluster_name}--{clean_annotation}--{clean_group}--{annot_scope}--{method}.tsv'
+            out_file = f'{cluster_name}--{clean_annotation}--{clean_group}--{annot_scope}--{method}.tsv'
             # Round numbers to 4 significant digits while respecting fixed point
             # and scientific notation (note: trailing zeros are removed)
             rank.to_csv(out_file, sep='\t', float_format='%.4g')

--- a/ingest/de.py
+++ b/ingest/de.py
@@ -412,6 +412,10 @@ class DifferentialExpression:
 
     @staticmethod
     def sanitize_strings(input_string):
+        """
+        Replace '+' with 'pos', then replace non-alphanumerics with underscore
+        this allows distinct sanitization for "CD16+ monocyte" vs "CD16- monocyte"
+        """
         plus_converted_string = re.sub('\+', 'pos', input_string)
         return re.sub(r'\W', '_', plus_converted_string)
 


### PR DESCRIPTION
In SCP1288, we found that filename sanitization (converting all non-alphanumeric to underscore) could cause a problem where two cluster/annotation/group names that only differ by "+" or "-" would result in a single filename (ie. the 2nd result would clobber the first and both names would reference the same file with one name yielding incorrect data).

Example 
`groups CD16+_Monocyte` and `CD16-_Monocyte` both result in the following filename:
UMAP_Cell_Embeddings--FinalCellType--CD16__Monocyte--study--wilcoxon.tsv

Implementation:
where "+" in cluster/annotation/group names for DE, replace with "pos"
note: "-" is converted to underscore

Manual test:

activate the scp-ingest-pipeline repo virtualenv
then from the ingest directory of the scp-ingest-pipeline repo, perform this setup:

> source ../scripts/setup_mongo_dev.sh <path/to/your/Github/token>
> unset BARD_HOST_URL

Run the DE job from the ingest directory of the scp-ingest-pipeline repo:

```
python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 differential_expression --annotation-name misc++cellaneous --annotation-type group --annotation-scope study --matrix-file-path ../tests/data/differential_expression/de_dense_matrix.tsv --matrix-file-type dense --annotation-file ../tests/data/differential_expression/de_dense_metadata_sanitize.txt --cluster-file ../tests/data/differential_expression/de_dense_cluster.tsv --cluster-name "UMAP, pre-QC all cells (complexity greater than or equal to 1000)" --study-accession SCPsanitize --differential-expression
```

confirm that the job runs successfully and in the output files annotation-name "misc++cellaneous" now has "pospos" where "++" was:

```
UMAP__pre_QC_all_cells__complexity_greater_than_or_equal_to_1000_--miscposposcellaneous--cholinergic__neuron_--study--wilcoxon.tsv
UMAP__pre_QC_all_cells__complexity_greater_than_or_equal_to_1000_--miscposposcellaneous--cranial__somatomotor__neuron--study--wilcoxon.tsv
UMAP__pre_QC_all_cells__complexity_greater_than_or_equal_to_1000_--miscposposcellaneous--pyramidal__neuron--study--wilcoxon.tsv
UMAP__pre_QC_all_cells__complexity_greater_than_or_equal_to_1000_--miscposposcellaneous--somatomotor_neuron_--study--wilcoxon.tsv
UMAP__pre_QC_all_cells__complexity_greater_than_or_equal_to_1000_--miscposposcellaneous--sympathetic__cholinergic_neuron--study--wilcoxon.tsv
```

This PR satisfies SCP-4533.
