### PR TITLE
Handle existing inserts when retrying from dropped MongoDB connection (SCP-4621)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ FROM marketplace.gcr.io/google/ubuntu1804:latest
 
 # Install Python 3.7
 RUN apt-get -y update && \
-  apt -y install software-properties-common && \
+  apt-get -y install software-properties-common && \
   add-apt-repository ppa:deadsnakes/ppa && \
-  apt -y install python3-pip && \
-  apt -y install python3.7 && \
-  apt -y install python3.7-dev
+  apt-get -y install python3-pip && \
+  apt-get -y install python3.7 && \
+  apt-get -y install python3.7-dev
 
 RUN python3.7 -m pip install --upgrade pip
 

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -117,16 +117,14 @@ def discard_inserted_documents(error_doc, original_documents, collection_name, m
            List[Dict]: list of documents with existing entries removed
     """
     names_to_find = list(doc['name'] for doc in original_documents)
-    study_id = error_doc['study_id']
-    study_file_id = error_doc['study_file_id']
-    linear_data_type = error_doc['linear_data_type']
     query = {
-        "study_id" : study_id,
-        "study_file_id" : study_file_id,
-        "linear_data_type" : linear_data_type,
-        "name" : { "$in" : names_to_find }
+        'study_id' : error_doc['study_id'],
+        'study_file_id' : error_doc['study_file_id'],
+        'name' : { "$in" : names_to_find }
     }
-    fields = { "name": 1 }
+    if 'linear_data_type' in error_doc:
+        query['linear_data_type'] = error_doc['linear_data_type']
+    fields = { 'name': 1 }
     raw_names = mongo_client[collection_name].find(query, fields)
     existing_names = list(doc['name'] for doc in raw_names)
     return list(doc for doc in original_documents if doc['name'] not in existing_names)

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -116,15 +116,14 @@ def discard_inserted_documents(error_doc, original_documents, collection_name, m
        Returns:
            List[Dict]: list of documents with existing entries removed
     """
-    names_to_find = list(doc['name'] for doc in original_documents)
+    names_to_find = list({'name': doc['name'], 'array_index': doc['array_index']} for doc in original_documents)
     query = {
         'study_id' : error_doc['study_id'],
         'study_file_id' : error_doc['study_file_id'],
+        'linear_data_type': error_doc['linear_data_type'],
         'name' : { "$in" : names_to_find }
     }
-    if 'linear_data_type' in error_doc:
-        query['linear_data_type'] = error_doc['linear_data_type']
-    fields = { 'name': 1 }
-    raw_names = mongo_client[collection_name].find(query, fields)
-    existing_names = list(doc['name'] for doc in raw_names)
-    return list(doc for doc in original_documents if doc['name'] not in existing_names)
+    fields = { 'name': 1, 'array_index': 1 }
+    raw_docs = mongo_client[collection_name].find(query, fields)
+    found_docs = list({ 'name': doc['name'], 'array_index': doc['array_index']} for doc in raw_docs)
+    return list(d for d in original_documents if {'name': d['name'], 'array_index': d['array_index']} not in found_docs)

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -109,8 +109,6 @@ def discard_inserted_documents(errors, original_documents):
     """Discard any documents that have already been inserted which are violating index constraints
        such documents will have an error code of 11000 for a DuplicateKey error
        from https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml#L467
-       Uses Mongo query to get existing names and filters against documents to be inserted as
-       only first error is returned, not all possible errors
 
        Parameters:
            errors (List<Dict>): Documents that failed to insert from transaction

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import functools
 import time

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -105,17 +105,14 @@ def log_error_without_values(error):
             entry['op']['values'] = '<filtered>'
     dev_logger.debug(str(error.details))
 
-def discard_inserted_documents(errors, original_documents):
+def discard_inserted_documents(errors, original_documents) -> list[dict]:
     """Discard any documents that have already been inserted which are violating index constraints
-       such documents will have an error code of 11000 for a DuplicateKey error
-       from https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml#L467
+    such documents will have an error code of 11000 for a DuplicateKey error
+    from https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml#L467
 
-       Parameters:
-           errors (List<Dict>): Documents that failed to insert from transaction
-           original_documents (List<Dict>): list of documents from original transaction that failed
-
-       Returns:
-           List<Dict>: list of documents with existing entries removed
+    :param errors: (list[dict]) Documents that failed to insert from transaction
+    :param original_documents: (list[dict]) list of documents from original transaction that failed
+    :returns list[dict]: list of documents with existing entries removed
     """
     error_docs = []
     for doc in errors:

--- a/tests/test_discard_documents.py
+++ b/tests/test_discard_documents.py
@@ -2,34 +2,34 @@ import unittest
 import sys
 sys.path.append("../ingest")
 from mongo_connection import discard_inserted_documents
+from unittest.mock import MagicMock
 
+client_values = { "data_arrays": MagicMock() }
+client_values["data_arrays"].find.return_value = [
+    { 'id': 1, 'name': 'foo' },
+    { 'id': 2, 'name': 'bar' }
+]
 
 class TestDiscardDocuments(unittest.TestCase):
+    # mock MongoDB client to return data from client_values
+    client_mock: MagicMock = MagicMock()
+    client_mock.keys.return_value.__iter__.return_value = client_values.keys()
+    client_mock.__getitem__.side_effect = lambda k: client_values[k]
+
     # test discarding documents from insert_many callback that have 11000 error code
     def test_discard_inserted_documents(self):
-        error_docs = [
-            {
-                'code': 11000,
-                'op': {'id': 1, 'foo': 'bar', 'bing': 'baz'}
-            },
-            {
-                'code': 11000,
-                'op': {'id': 2, 'foo': 'bar', 'bing': 'blurg'}
-            },
-            {
-                'code': 11001,
-                'op': {'id': 3, 'blah': 'blurg', 'boo': 'bah'}
-            }
-        ]
-
+        error_doc = { 'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene' }
         original_docs = [
-            {'id': 1, 'foo': 'bar', 'bing': 'baz'},
-            {'id': 2, 'foo': 'bar', 'bing': 'blurg'},
-            {'id': 3, 'blah': 'blurg', 'boo': 'bah'},
-            {'id': 4, 'blah': 'barf', 'boo': 'bee'}
+            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
+            {'id': 2, 'name': 'bar', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
+            {'id': 3, 'name': 'blurg', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
+            {'id': 4, 'name': 'barf', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'}
         ]
 
-        filtered_docs = discard_inserted_documents(error_docs, original_docs)
+        filtered_docs = discard_inserted_documents(error_doc,
+                                                   original_docs,
+                                                   'data_arrays',
+                                                   TestDiscardDocuments.client_mock)
         self.assertEqual(2, len(filtered_docs), 'Did not correctly return 2 filtered documents')
         ids = list(doc['id'] for doc in filtered_docs)
         ids.sort()

--- a/tests/test_discard_documents.py
+++ b/tests/test_discard_documents.py
@@ -2,36 +2,23 @@ import unittest
 import sys
 sys.path.append("../ingest")
 from mongo_connection import discard_inserted_documents
-from unittest.mock import MagicMock
-
-client_values = { "data_arrays": MagicMock() }
-client_values["data_arrays"].find.return_value = [
-    { 'id': 1, 'name': 'foo', 'array_index': 0 },
-    { 'id': 3, 'name': 'bar', 'array_index': 0 }
-]
 
 class TestDiscardDocuments(unittest.TestCase):
-    # mock MongoDB client to return data from client_values
-    client_mock: MagicMock = MagicMock()
-    client_mock.keys.return_value.__iter__.return_value = client_values.keys()
-    client_mock.__getitem__.side_effect = lambda k: client_values[k]
-
     # test discarding documents from insert_many callback that have 11000 error code
     def test_discard_inserted_documents(self):
-        error_doc = { 'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene' }
-        original_docs = [
-            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'},
-            {'id': 2, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'array_index': 1, 'linear_data_type': 'Gene'},
-            {'id': 3, 'name': 'bar', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'},
-            {'id': 4, 'name': 'blurg', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'},
-            {'id': 5, 'name': 'barf', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'}
+        error_docs = [
+            {'code': 11000, 'op': {'id': 1, 'name': 'foo', 'array_index': 0}},
+            {'code': 11000, 'op': {'id': 3, 'name': 'bar', 'array_index': 0}},
         ]
-
-        filtered_docs = discard_inserted_documents(error_doc,
-                                                   original_docs,
-                                                   'data_arrays',
-                                                   TestDiscardDocuments.client_mock)
-        self.assertEqual(3, len(filtered_docs), 'Did not correctly return 2 filtered documents')
+        original_docs = [
+            {'id': 1, 'name': 'foo', 'array_index': 0},
+            {'id': 2, 'name': 'foo', 'array_index': 1},
+            {'id': 3, 'name': 'bar', 'array_index': 0},
+            {'id': 4, 'name': 'blurg','array_index': 0},
+            {'id': 5, 'name': 'barf', 'array_index': 0}
+        ]
+        filtered_docs = discard_inserted_documents(error_docs, original_docs)
+        self.assertEqual(3, len(filtered_docs), 'Did not correctly return 3 filtered documents')
         ids = list(doc['id'] for doc in filtered_docs)
         ids.sort()
         self.assertEqual([2, 4, 5], ids, 'Did not return correct IDs')

--- a/tests/test_discard_documents.py
+++ b/tests/test_discard_documents.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 
 client_values = { "data_arrays": MagicMock() }
 client_values["data_arrays"].find.return_value = [
-    { 'id': 1, 'name': 'foo' },
-    { 'id': 2, 'name': 'bar' }
+    { 'id': 1, 'name': 'foo', 'array_index': 0 },
+    { 'id': 3, 'name': 'bar', 'array_index': 0 }
 ]
 
 class TestDiscardDocuments(unittest.TestCase):
@@ -20,17 +20,18 @@ class TestDiscardDocuments(unittest.TestCase):
     def test_discard_inserted_documents(self):
         error_doc = { 'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene' }
         original_docs = [
-            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
-            {'id': 2, 'name': 'bar', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
-            {'id': 3, 'name': 'blurg', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
-            {'id': 4, 'name': 'barf', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'}
+            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'},
+            {'id': 2, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'array_index': 1, 'linear_data_type': 'Gene'},
+            {'id': 3, 'name': 'bar', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'},
+            {'id': 4, 'name': 'blurg', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'},
+            {'id': 5, 'name': 'barf', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'}
         ]
 
         filtered_docs = discard_inserted_documents(error_doc,
                                                    original_docs,
                                                    'data_arrays',
                                                    TestDiscardDocuments.client_mock)
-        self.assertEqual(2, len(filtered_docs), 'Did not correctly return 2 filtered documents')
+        self.assertEqual(3, len(filtered_docs), 'Did not correctly return 2 filtered documents')
         ids = list(doc['id'] for doc in filtered_docs)
         ids.sort()
-        self.assertEqual([3, 4], ids, 'Did not return correct IDs')
+        self.assertEqual([2, 4, 5], ids, 'Did not return correct IDs')

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -370,8 +370,8 @@ class TestExpressionFiles(unittest.TestCase):
         client_mock = MagicMock()
 
         docs = [
-            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
-            {'id': 2, 'name': 'bar', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'}
+            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'},
+            {'id': 2, 'name': 'bar', 'study_id': 1, 'study_file_id': 1, 'array_index': 0, 'linear_data_type': 'Gene'}
         ]
         GeneExpression.insert(docs, "collection", client_mock)
         client_mock["collection"].insert_many.assert_called_with(docs, ordered=False)
@@ -393,10 +393,9 @@ class TestExpressionFiles(unittest.TestCase):
         def raiseError(*args, **kwargs):
             details = {
                 "writeErrors": [
-                    {
-                        "code": 11000,
-                        "op":
-                            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'}
+                    { "code": 11000, "op": {
+                        'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1,
+                        'array_index': 0, 'linear_data_type': 'Gene'}
                     }
                 ]
             }

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -370,8 +370,8 @@ class TestExpressionFiles(unittest.TestCase):
         client_mock = MagicMock()
 
         docs = [
-            {"values": ["foo3", "foo4", "foo5"]},
-            {"values": ["foo6", "foo7", "foo8"]},
+            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'},
+            {'id': 2, 'name': 'bar', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'}
         ]
         GeneExpression.insert(docs, "collection", client_mock)
         client_mock["collection"].insert_many.assert_called_with(docs, ordered=False)
@@ -391,8 +391,15 @@ class TestExpressionFiles(unittest.TestCase):
         client_mock.reset_mock()
 
         def raiseError(*args, **kwargs):
-            details = {"writeErrors": [{"code": 2345}]}
-
+            details = {
+                "writeErrors": [
+                    {
+                        "code": 11000,
+                        "op":
+                            {'id': 1, 'name': 'foo', 'study_id': 1, 'study_file_id': 1, 'linear_data_type': 'Gene'}
+                    }
+                ]
+            }
             raise BulkWriteError(details)
 
         # Test exponential back off for BulkWriteError


### PR DESCRIPTION
#### BACKGROUND
Very large expression matrices (e.g. > 10 GiB) are prone to connection issues during ingest.  While the cause is not fully understood, one theory is that expression matrices with both high cell counts & high proportions of expressed cells cause timeouts when inserting into MongoDB due to the large amount of data sent to and received back from the database.  Current retry functionality has been shown to be very brittle with extremely large files, causing repeated failed ingests.

#### CHANGES
While investigating a 47 GiB matrix that failed to ingest, it was discovered that our logic for filtering out documents that may have already been inserted before the connection was dropped was faulty, and as such may not catch all potential errors.  The updated filtering methodology only matches on the document `name` and `array_index` (rather than the entire document) as these two properties alone will constitute a unique key.  This update also filters out the `values` array from `DataArray` documents when logging errors to make debugging easier for extremely large arrays.

This update also corrects an issue with building the Docker image locally where `apt` cannot connect to some repositories and is replaced with `apt-get`, which does not appear to have the same issues.

#### MANUAL TESTING
Since this problem only manifests when attempting to ingest very large matrices, manual testing cannot be done in the context of a normal PR review (aside from running the tests) as the ingest process takes hours to complete.  However, this updated code has ingested the entire 47 GiB dense matrix twice, taking slightly over 4 hours both times.