### PR TITLE
Allow clustering_dimension for 2 dimensions (SCP-4828)

### DIFF
--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -53,7 +53,7 @@ class AnnDataIngestor(IngestFiles):
         clustering_dimension = adata.obsm[clustering_name].shape[1]
         if clustering_dimension == 3:
             headers = dim.append('Z')
-        elif clustering_dimension == 3:
+        elif clustering_dimension == 2:
             headers = dim
         elif clustering_dimension > 3:
             msg = f"Too many dimensions for visualization in obsm \"{clustering_name}\", found {clustering_dimension}, expected 2 or 3."


### PR DESCRIPTION
When ingesting a file, I received this error:
`ValueError: Too few dimensions for visualization in obsm "X_umap", found 2, expected 2 or 3.`

The check for clustering_dimension didn't allow for just 2 (X, and Y) so just adding that.