### PR TITLE
Check that "extract cluster" argument is True

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -613,7 +613,7 @@ def exit_pipeline(ingest, status, status_cell_metadata, arguments):
                     file_path, study_file_id, files_to_match
                 )
         # for successful anndata jobs, need to delocalize intermediate ingest files
-        elif "extract_cluster" in arguments and all(i < 1 for i in status):
+        elif "extract_cluster" in arguments and arguments.get("extract_cluster") == True and all(i < 1 for i in status):
             file_path, study_file_id = get_delocalization_info(arguments)
             # append status?
             if IngestFiles.is_remote_file(file_path):


### PR DESCRIPTION
Previously we were only checking that the argument 'extract cluster' was contained in the argument object to decide whether or not to do the cluster extraction from the AnnData file. However, in playing around locally I realized that that argument is always included in the arguments obj just set  to False or True so now doing that check to only continue with the full ingest when appropriate.


![Screen Shot 2022-11-28 at 3 23 09 PM](https://user-images.githubusercontent.com/54322292/204374755-0c19f38f-b2d5-421a-a22f-96f38c4b4a36.png)
![Screen Shot 2022-11-28 at 3 29 42 PM](https://user-images.githubusercontent.com/54322292/204374760-4a15ab59-3d22-4270-8a08-d2ed3b7380b5.png)
