### PR TITLE
Correctly set filename when delocalizing extracted clustering files (SCP-4831)

### DIFF
--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -84,7 +84,7 @@ class AnnDataIngestor(IngestFiles):
             [cluster_cells, pd.DataFrame(adata.obsm[clustering_name])], axis=1
         )
         pd.DataFrame(cluster_body).to_csv(
-            f"{clustering_name}.cluster.anndata_segment.tsv",
+            AnnDataIngestor.set_output_filename(clustering_name),
             sep="\t",
             mode="a",
             header=None,
@@ -94,8 +94,12 @@ class AnnDataIngestor(IngestFiles):
     @staticmethod
     def files_to_delocalize(arguments):
         # ToDo - check if names using obsm_keys need sanitization
-        cluster_file_names = [name + ".tsv" for name in arguments["obsm_keys"]]
+        cluster_file_names = [AnnDataIngestor.set_output_filename(name) for name in arguments["obsm_keys"]]
         return cluster_file_names
+
+    @staticmethod
+    def set_output_filename(name):
+        return f"{name}.cluster.anndata_segment.tsv"
 
     @staticmethod
     def delocalize_cluster_files(file_path, study_file_id, files_to_delocalize):

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -52,3 +52,10 @@ class TestAnnDataIngestor(unittest.TestCase):
         )
         self.assertFalse(bad_input.validate())
 
+    def test_set_output_filename(self):
+        cluster_name = "X_Umap"
+        self.assertEqual(
+            AnnDataIngestor.set_output_filename(cluster_name),
+            "X_Umap.cluster.anndata_segment.tsv"
+        )
+


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug where extracted clustering files are not delocalized back to the source bucket when running `AnnData` ingest jobs.  The issue is that filenames are not correctly set and passed to downstream methods.  There is now a single place where filenames are set and this method is referenced where needed.

#### MANUAL TESTING
1. Download the h5ad file from https://cellxgene.cziscience.com/collections/2902f08c-f83c-470e-a541-e463e25e5058 and place it in any bucket that you have access to at the root folder
2. Run ingest pipeline via command line
a. Activate the scp-ingest-pipeline repo virtualenv
b. From the ingest directory of the scp-ingest-pipeline repo, perform this setup:
source ../scripts/setup_mongo_dev.sh <path to your Github token file>
3. Run the following command, pasting in the correct bucket id:
```
BUCKET_ID="fc-45f2ff6d-92f5-4cad-9c6b-a4a832c2a2d7"; python3 ingest_pipeline.py --study-id 63878fb7d17c6300547fe22b --study-file-id 638e223134fe9d7293df682d --user-metrics-uuid f775823b-94f7-46af-b1c7-789582efaa27 ingest_anndata --ingest-anndata --anndata-file gs://$BUCKET_ID/local.h5ad --extract-cluster --obsm-keys "['X_umap','X_tsne']"
```
4. Once the command finishes, go to the bucket in a browser window and validate that the following files have been added to the `_scp_internal/anndata_ingest` directory:
![Screen Shot 2022-12-05 at 12 30 19 PM](https://user-images.githubusercontent.com/729968/205703434-990b8ba4-58e6-45af-9334-75b2aaa0f3da.png)
