### PR TITLE
Adding test coverage for `AnnDataIngestor` (SCP-4825)

### DIFF
--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -31,9 +31,7 @@ class TestAnnDataIngestor(unittest.TestCase):
             os.remove(self.output_filename)
 
     def test_minimal_valid_anndata(self):
-        self.assertTrue(
-            self.anndata_ingest.validate(), "expect known good file to open with scanpy"
-        )
+        self.assertTrue(self.anndata_ingest.validate(), "expect known good file to open with scanpy")
 
     def test_truncated_anndata(self):
         truncated_input = AnnDataIngestor(*self.invalid_args)
@@ -69,9 +67,6 @@ class TestAnnDataIngestor(unittest.TestCase):
             AnnDataIngestor.set_output_filename(cluster_name),
             "X_Umap.cluster.anndata_segment.tsv"
         )
-
-    def test_validate(self):
-        self.assertTrue(self.anndata_ingest.validate(), "Did not load adata from h5ad file")
 
     def test_generate_cluster_header(self):
         self.anndata_ingest.generate_cluster_header(self.anndata_ingest.obtain_adata(), self.cluster_name)

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -4,28 +4,39 @@
 
 import unittest
 import sys
+import os
+from unittest.mock import patch
 
 sys.path.append("../ingest")
 from anndata_ import AnnDataIngestor
-
+from ingest_files import IngestFiles
 
 class TestAnnDataIngestor(unittest.TestCase):
+
+    @staticmethod
+    def setup_class(self):
+        filepath_valid = "../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad"
+        filepath_invalid = "../tests/data/anndata/bad.h5"
+        self.study_id = "addedfeed000000000000000"
+        self.study_file_id = "dec0dedfeed0000000000000"
+        self.valid_args = [filepath_valid, self.study_id, self.study_file_id]
+        self.invalid_args = [filepath_invalid, self.study_id, self.study_file_id]
+        self.cluster_name = 'X_tsne'
+        self.valid_kwargs = {'obsm_keys': [self.cluster_name]}
+        self.anndata_ingest = AnnDataIngestor(*self.valid_args, **self.valid_kwargs)
+        self.output_filename = f"{self.cluster_name}.cluster.anndata_segment.tsv"
+
+    def teardown_method(self, _):
+        if os.path.isfile(self.output_filename):
+            os.remove(self.output_filename)
+
     def test_minimal_valid_anndata(self):
-        good_input = AnnDataIngestor(
-            "../tests/data/anndata/test.h5ad",
-            "addedfeed000000000000000",
-            "dec0dedfeed0000000000000",
-        )
         self.assertTrue(
-            good_input.validate(), "expect known good file to open with scanpy"
+            self.anndata_ingest.validate(), "expect known good file to open with scanpy"
         )
 
     def test_truncated_anndata(self):
-        truncated_input = AnnDataIngestor(
-            "../tests/data/anndata/bad.h5",
-            "addedfeed000000000000000",
-            "dec0dedfeed0000000000000",
-        )
+        truncated_input = AnnDataIngestor(*self.invalid_args)
         # passing obtain_data function to assertRaises using lambda
         # otherwise truncated_input.obtain_data() is evaluated and triggers
         # an exception before assertRaises gets called
@@ -39,8 +50,8 @@ class TestAnnDataIngestor(unittest.TestCase):
     def test_input_bad_suffix(self):
         bad_input = AnnDataIngestor(
             "../tests/data/anndata/bad.foo",
-            "addedfeed000000000000000",
-            "dec0dedfeed0000000000000",
+            self.study_id,
+            self.study_file_id,
         )
         # passing obtain_data function to assertRaises using lambda
         # otherwise bad_input.obtain_data() is evaluated and triggers
@@ -59,3 +70,42 @@ class TestAnnDataIngestor(unittest.TestCase):
             "X_Umap.cluster.anndata_segment.tsv"
         )
 
+    def test_validate(self):
+        self.assertTrue(self.anndata_ingest.validate(), "Did not load adata from h5ad file")
+
+    def test_generate_cluster_header(self):
+        self.anndata_ingest.generate_cluster_header(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        with open(self.output_filename) as header_file:
+            header = header_file.readline().split("\t")
+            self.assertEqual(['NAME', 'X', "Y\n"], header, "did not find expected headers")
+
+    def test_generate_cluster_type_declaration(self):
+        self.anndata_ingest.generate_cluster_type_declaration(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        with open(self.output_filename) as header_file:
+            header = header_file.readline().split("\t")
+            self.assertEqual(['TYPE', 'numeric', "numeric\n"], header, "did not find expected headers")
+
+    def test_generate_cluster_body(self):
+        self.anndata_ingest.generate_cluster_body(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        with open(self.output_filename) as cluster_body:
+            line = cluster_body.readline().split("\t")
+            expected_line = ['AAACATACAACCAC-1', '16.009954', "-21.073845\n"]
+            self.assertEqual(expected_line, line, 'did not get expected coordinates from cluster body')
+
+    def test_get_files_to_delocalize(self):
+        files = AnnDataIngestor.files_to_delocalize(self.valid_kwargs)
+        expected_files = [self.output_filename]
+        self.assertEqual(expected_files, files)
+
+    def test_delocalize_files(self):
+        # just create header, no reason to run full extract
+        self.anndata_ingest.generate_cluster_header(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        with patch('ingest_files.IngestFiles.delocalize_file'):
+            AnnDataIngestor.delocalize_file(
+                "gs://fake_bucket", self.study_id, AnnDataIngestor.files_to_delocalize(self.valid_kwargs)
+            )
+            self.assertEqual(
+                IngestFiles.delocalize_file.call_count,
+                1,
+                "expected 1 calls to delocalize output files",
+            )

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -102,5 +102,5 @@ class TestAnnDataIngestor(unittest.TestCase):
             self.assertEqual(
                 IngestFiles.delocalize_file.call_count,
                 1,
-                "expected 1 calls to delocalize output files",
+                "expected 1 call to delocalize output files",
             )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -46,10 +46,9 @@ from ingest_pipeline import (
     validate_arguments,
     IngestPipeline,
     exit_pipeline,
-    run_ingest,
+    run_ingest
 )
 from expression_files.expression_files import GeneExpression
-
 
 def mock_load(self, *args, **kwargs):
     """Enables overwriting normal function with this placeholder.
@@ -674,6 +673,27 @@ class IngestTestCase(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm, self.assertRaises(ValueError):
             exit_pipeline(ingest, status, status_cell_metadata, arguments)
         self.assertEqual(cm.exception.code, 1)
+
+    def test_extract_cluster_file_from_anndata(self):
+        args = [
+            "--study-id",
+            "5d276a50421aa9117c982845",
+            "--study-file-id",
+            "5dd5ae25421aa910a723a337",
+            "ingest_anndata",
+            "--ingest-anndata",
+            "--extract-cluster",
+            "--anndata-file",
+            "../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad",
+            "--obsm-keys",
+            "['X_tsne']"
+
+        ]
+        ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
+        self.assertEqual(len(status), 1)
+        self.assertEqual(status[0], 0)
+        filename = 'X_tsne.cluster.anndata_segment.tsv'
+        self.assertTrue(os.path.isfile(filename))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds full test coverage for `AnnDataIngestor`.  This will give us a working test harness moving forward that we can add to as we implement more data extraction methods to this class to ensure no regressions.

#### MANUAL TESTING
1. Pull this branch and initialize the `virtualenv` with:
```
python3 -m venv env --copies                               
source env/bin/activate
pip install -r requirements.txt
```
2. Go to the `tests` directory and run the following tests, ensuring that none fail:
(note: you will see a _lot_ of warnings that I was unable to silence, but there should be no failed tests).
```
pytest test_anndata.py
pytest test_ingest.py -k 'test_extract_cluster_file_from_anndata'
```  