### PR TITLE
Extract metadata from h5ad and delocalize ingest-intermediate files to study bucket (SCP-4823)

### DIFF
--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -354,9 +354,9 @@ def create_parser():
     )
 
     parser_anndata.add_argument(
-        "--extract-cluster",
-        action="store_true",
-        help="Indicates clustering data should be extracted",
+        "--extract",
+        type=ast.literal_eval,
+        help="Array of file types to extract, options include ['cluster', 'matrix']",
     )
 
     parser_expression_writer = subparsers.add_parser(

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -356,7 +356,7 @@ def create_parser():
     parser_anndata.add_argument(
         "--extract",
         type=ast.literal_eval,
-        help="Array of file types to extract, options include ['cluster', 'matrix']",
+        help="Array of file types to extract, options include ['cluster', 'metadata']",
     )
 
     parser_expression_writer = subparsers.add_parser(

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -498,19 +498,15 @@ class IngestPipeline:
                 if not self.kwargs["obsm_keys"]:
                     self.kwargs["obsm_keys"] = ['X_tsne']
                 for key in self.kwargs["obsm_keys"]:
-                    AnnDataIngestor.generate_cluster_header(
-                        self.anndata.adata, key, file_id
-                    )
+                    AnnDataIngestor.generate_cluster_header(self.anndata.adata, key)
                     AnnDataIngestor.generate_cluster_type_declaration(
-                        self.anndata.adata, key, file_id
+                        self.anndata.adata, key
                     )
-                    AnnDataIngestor.generate_cluster_body(
-                        self.anndata.adata, key, file_id
-                    )
+                    AnnDataIngestor.generate_cluster_body(self.anndata.adata, key)
             if self.kwargs.get("extract") and "metadata" in self.kwargs.get("extract"):
-                output_filename = f"{outfile_prefix}.metadata.anndata_segment.tsv"
+                metadata_filename = f"h5ad_frag.metadata.tsv"
                 AnnDataIngestor.generate_metadata_file(
-                    self.anndata.adata, output_filename
+                    self.anndata.adata, metadata_filename
                 )
             return 0
         # scanpy unable to open AnnData file
@@ -643,13 +639,11 @@ def exit_pipeline(ingest, status, status_cell_metadata, arguments):
                 file_id = study_info.get_properties()['fileName']
                 if "cluster" in arguments.get("extract"):
                     files_to_delocalize.extend(
-                        AnnDataIngestor.clusterings_to_delocalize(arguments, file_id)
+                        AnnDataIngestor.clusterings_to_delocalize(arguments)
                     )
                 if "metadata" in arguments.get("extract"):
-                    output_filename = (
-                        f"{file_id}.{accession}.metadata.anndata_segment.tsv"
-                    )
-                    files_to_delocalize.append(output_filename)
+                    metadata_filename = f"h5ad_frag.metadata.tsv"
+                    files_to_delocalize.append(metadata_filename)
                 AnnDataIngestor.delocalize_extracted_files(
                     file_path, study_file_id, files_to_delocalize
                 )

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -30,7 +30,7 @@ python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5d
 python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --ingest-anndata --anndata-file ../tests/data/anndata/test.h5ad
 
 # Ingest AnnData file - cluster extraction
-python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --extract-cluster --ingest-anndata --anndata-file ../tests/data/anndata/test.h5ad --obsm-keys "['X_tsne']"
+python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --extract "['cluster']" --ingest-anndata --anndata-file ../tests/data/anndata/test.h5ad --obsm-keys "['X_tsne']"
 
 # Subsample cluster and metadata file
 python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_subsample --cluster-file ../tests/data/test_1k_cluster_data.csv --name cluster1 --cell-metadata-file ../tests/data/test_1k_metadata_Data.csv --subsample
@@ -490,7 +490,7 @@ class IngestPipeline:
         )
         if self.anndata.validate():
             self.report_validation("success")
-            if self.kwargs["extract_cluster"] == True:
+            if self.kwargs.get("extract") and "cluster" in self.kwargs.get("extract"):
                 if not self.kwargs["obsm_keys"]:
                     self.kwargs["obsm_keys"] = ['X_tsne']
                 for key in self.kwargs["obsm_keys"]:
@@ -619,8 +619,8 @@ def exit_pipeline(ingest, status, status_cell_metadata, arguments):
                 )
         # for successful anndata jobs, need to delocalize intermediate ingest files
         elif (
-            "extract_cluster" in arguments
-            and arguments.get("extract_cluster") == True
+            arguments.get("extract")
+            and "cluster" in arguments.get("extract")
             and all(i < 1 for i in status)
         ):
             file_path, study_file_id = get_delocalization_info(arguments)

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -11,8 +11,8 @@ sys.path.append("../ingest")
 from anndata_ import AnnDataIngestor
 from ingest_files import IngestFiles
 
-class TestAnnDataIngestor(unittest.TestCase):
 
+class TestAnnDataIngestor(unittest.TestCase):
     @staticmethod
     def setup_class(self):
         filepath_valid = "../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad"
@@ -24,14 +24,18 @@ class TestAnnDataIngestor(unittest.TestCase):
         self.cluster_name = 'X_tsne'
         self.valid_kwargs = {'obsm_keys': [self.cluster_name]}
         self.anndata_ingest = AnnDataIngestor(*self.valid_args, **self.valid_kwargs)
-        self.output_filename = f"{self.cluster_name}.cluster.anndata_segment.tsv"
+        self.output_filename = (
+            f"{self.study_file_id}.{self.cluster_name}.cluster.anndata_segment.tsv"
+        )
 
     def teardown_method(self, _):
         if os.path.isfile(self.output_filename):
             os.remove(self.output_filename)
 
     def test_minimal_valid_anndata(self):
-        self.assertTrue(self.anndata_ingest.validate(), "expect known good file to open with scanpy")
+        self.assertTrue(
+            self.anndata_ingest.validate(), "expect known good file to open with scanpy"
+        )
 
     def test_truncated_anndata(self):
         truncated_input = AnnDataIngestor(*self.invalid_args)
@@ -47,9 +51,7 @@ class TestAnnDataIngestor(unittest.TestCase):
 
     def test_input_bad_suffix(self):
         bad_input = AnnDataIngestor(
-            "../tests/data/anndata/bad.foo",
-            self.study_id,
-            self.study_file_id,
+            "../tests/data/anndata/bad.foo", self.study_id, self.study_file_id
         )
         # passing obtain_data function to assertRaises using lambda
         # otherwise bad_input.obtain_data() is evaluated and triggers
@@ -62,42 +64,66 @@ class TestAnnDataIngestor(unittest.TestCase):
         self.assertFalse(bad_input.validate())
 
     def test_set_output_filename(self):
-        cluster_name = "X_Umap"
+        cluster_name = "dec0dedfeed0000000000000.X_Umap"
         self.assertEqual(
-            AnnDataIngestor.set_output_filename(cluster_name),
-            "X_Umap.cluster.anndata_segment.tsv"
+            AnnDataIngestor.set_clustering_filename(cluster_name),
+            "dec0dedfeed0000000000000.X_Umap.cluster.anndata_segment.tsv",
         )
 
     def test_generate_cluster_header(self):
-        self.anndata_ingest.generate_cluster_header(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        self.anndata_ingest.generate_cluster_header(
+            self.anndata_ingest.obtain_adata(), self.cluster_name, self.study_file_id
+        )
         with open(self.output_filename) as header_file:
             header = header_file.readline().split("\t")
-            self.assertEqual(['NAME', 'X', "Y\n"], header, "did not find expected headers")
+            self.assertEqual(
+                ['NAME', 'X', "Y\n"], header, "did not find expected headers"
+            )
 
     def test_generate_cluster_type_declaration(self):
-        self.anndata_ingest.generate_cluster_type_declaration(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        self.anndata_ingest.generate_cluster_type_declaration(
+            self.anndata_ingest.obtain_adata(), self.cluster_name, self.study_file_id
+        )
         with open(self.output_filename) as header_file:
             header = header_file.readline().split("\t")
-            self.assertEqual(['TYPE', 'numeric', "numeric\n"], header, "did not find expected headers")
+            self.assertEqual(
+                ['TYPE', 'numeric', "numeric\n"],
+                header,
+                "did not find expected headers",
+            )
 
     def test_generate_cluster_body(self):
-        self.anndata_ingest.generate_cluster_body(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        self.anndata_ingest.generate_cluster_body(
+            self.anndata_ingest.obtain_adata(), self.cluster_name, self.study_file_id
+        )
         with open(self.output_filename) as cluster_body:
             line = cluster_body.readline().split("\t")
             expected_line = ['AAACATACAACCAC-1', '16.009954', "-21.073845\n"]
-            self.assertEqual(expected_line, line, 'did not get expected coordinates from cluster body')
+            self.assertEqual(
+                expected_line,
+                line,
+                'did not get expected coordinates from cluster body',
+            )
 
     def test_get_files_to_delocalize(self):
-        files = AnnDataIngestor.files_to_delocalize(self.valid_kwargs)
+        files = AnnDataIngestor.clusterings_to_delocalize(
+            self.valid_kwargs, self.study_file_id
+        )
         expected_files = [self.output_filename]
         self.assertEqual(expected_files, files)
 
     def test_delocalize_files(self):
         # just create header, no reason to run full extract
-        self.anndata_ingest.generate_cluster_header(self.anndata_ingest.obtain_adata(), self.cluster_name)
+        self.anndata_ingest.generate_cluster_header(
+            self.anndata_ingest.obtain_adata(), self.cluster_name, self.study_file_id
+        )
         with patch('ingest_files.IngestFiles.delocalize_file'):
             AnnDataIngestor.delocalize_file(
-                "gs://fake_bucket", self.study_id, AnnDataIngestor.files_to_delocalize(self.valid_kwargs)
+                "gs://fake_bucket",
+                self.study_id,
+                AnnDataIngestor.clusterings_to_delocalize(
+                    self.valid_kwargs, self.study_file_id
+                ),
             )
             self.assertEqual(
                 IngestFiles.delocalize_file.call_count,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -693,7 +693,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
         self.assertEqual(len(status), 1)
         self.assertEqual(status[0], 0)
-        filename = '5dd5ae25421aa910a723a337.X_tsne.cluster.anndata_segment.tsv'
+        filename = 'h5ad_frag.cluster.X_tsne.tsv'
         self.assertTrue(os.path.isfile(filename))
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -693,7 +693,7 @@ class IngestTestCase(unittest.TestCase):
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
         self.assertEqual(len(status), 1)
         self.assertEqual(status[0], 0)
-        filename = 'X_tsne.cluster.anndata_segment.tsv'
+        filename = '5dd5ae25421aa910a723a337.X_tsne.cluster.anndata_segment.tsv'
         self.assertTrue(os.path.isfile(filename))
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -46,9 +46,10 @@ from ingest_pipeline import (
     validate_arguments,
     IngestPipeline,
     exit_pipeline,
-    run_ingest
+    run_ingest,
 )
 from expression_files.expression_files import GeneExpression
+
 
 def mock_load(self, *args, **kwargs):
     """Enables overwriting normal function with this placeholder.
@@ -682,12 +683,12 @@ class IngestTestCase(unittest.TestCase):
             "5dd5ae25421aa910a723a337",
             "ingest_anndata",
             "--ingest-anndata",
-            "--extract-cluster",
+            "--extract",
+            "['cluster']",
             "--anndata-file",
             "../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad",
             "--obsm-keys",
-            "['X_tsne']"
-
+            "['X_tsne']",
         ]
         ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
         self.assertEqual(len(status), 1)


### PR DESCRIPTION
This is a "happy path" implementation of extracting metadata from h5ad. 

#### Changes impacting Rails integration:
The "--extract-cluster" boolean is now the "--extract" flag with an array of values (currently array can contain "cluster" and/or "metadata"), which generates the specified SCP-compliant filetypes and delocalizes those intermediate files to the study bucket at _scp_internal/anndata_ingest 

Extracted files will be delocalized to a "subdirectory" (technically, the data is going into a object store so we're really just adding a segment in the file's name) named after the h5ad file's study_file_id. 

Extracted filenames follow this new structure:
<input_filetype>_frag.<file_type>.<file_type_detail>.tsv
input_filetype = h5ad_frag (replaces `anndata_segment`; other possible future types: seurat_frag, loom_frag)
file_type = cluster|metadata|matrix
file_type_detail [optional] = <clustering name> (for cluster files), raw|processed (for matrix files)


### To test:
Run anndata ingest using an example file from our development reference data GCP bucket.

**Before you start**, check the study bucket for delocalized output

> https://console.cloud.google.com/storage/browser/fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/

##### If there is an "_scp_internal" directory, delete it before you start.

1. Activate the scp-ingest-pipeline repo virtualenv
2. From the ingest directory of the scp-ingest-pipeline repo, perform this setup:

`source ../scripts/setup_mongo_dev.sh <path to your Github token file>`

If you get an authentication error from gcloud, run the following:
`gcloud auth application-default login --no-launch-browser`

3. Run the anndata ingest job from the ingest directory of the scp-ingest-pipeline repo:

`python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --ingest-anndata --anndata-file gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/ingest_manual_test/compliant_pbmc3K.h5ad  --extract "['cluster', 'metadata']" --obsm-keys "['X_umap','X_tsne']"`

4. Confirm that locally, in the ingest directory, you find intermediate ingest files:

> h5ad_frag.cluster.X_umap.tsv
> h5ad_frag.cluster.X_tsne.tsv
> h5ad_frag.metadata.tsv

5. Confirm that the job ran successfully by checking that the above outputs delocalized to:

> https://console.cloud.google.com/storage/browser/fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/_scp_internal/anndata_ingest/5dd5ae25421aa910a723a337

cluster file sample: 'gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/_scp_internal/anndata_ingest/5dd5ae25421aa910a723a337/h5ad_frag.cluster.X_tsne.tsv'

Due to time considerations, tests for metadata extraction are not yet implemented. A follow-on PR for tests and Mixpanel reporting integrations will be created. This fulfills implementation of the functional work for [SCP-4823](https://broadworkbench.atlassian.net/browse/SCP-4823) to unblock tickets to complete [SCP-4708](https://broadworkbench.atlassian.net/browse/SCP-4708).