### PR TITLE
Adding test coverage for metadata extraction (SCP-4863)

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -490,10 +490,6 @@ class IngestPipeline:
         )
         if self.anndata.validate():
             self.report_validation("success")
-            study_info = config.get_metric_properties()
-            accession = study_info.get_properties()['studyAccession']
-            file_id = study_info.get_properties()['fileName']
-            outfile_prefix = f"{file_id}.{accession}"
             if self.kwargs.get("extract") and "cluster" in self.kwargs.get("extract"):
                 if not self.kwargs["obsm_keys"]:
                     self.kwargs["obsm_keys"] = ['X_tsne']
@@ -632,11 +628,6 @@ def exit_pipeline(ingest, status, status_cell_metadata, arguments):
             # append status?
             files_to_delocalize = []
             if IngestFiles.is_remote_file(file_path):
-                # the next 3 lines are copied from 493-495, suggestions
-                # welcomed for how to DRY this up
-                study_info = config.get_metric_properties()
-                accession = study_info.get_properties()['studyAccession']
-                file_id = study_info.get_properties()['fileName']
                 if "cluster" in arguments.get("extract"):
                     files_to_delocalize.extend(
                         AnnDataIngestor.clusterings_to_delocalize(arguments)

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -24,11 +24,12 @@ class TestAnnDataIngestor(unittest.TestCase):
         self.cluster_name = 'X_tsne'
         self.valid_kwargs = {'obsm_keys': [self.cluster_name]}
         self.anndata_ingest = AnnDataIngestor(*self.valid_args, **self.valid_kwargs)
-        self.output_filename = f"h5ad_frag.cluster.{self.cluster_name}.tsv"
+        self.cluster_filename = f"h5ad_frag.cluster.{self.cluster_name}.tsv"
+        self.metadata_filename = "h5ad_frag.metadata.tsv"
 
     def teardown_method(self, _):
-        if os.path.isfile(self.output_filename):
-            os.remove(self.output_filename)
+        if os.path.isfile(self.cluster_filename):
+            os.remove(self.cluster_filename)
 
     def test_minimal_valid_anndata(self):
         self.assertTrue(
@@ -72,7 +73,7 @@ class TestAnnDataIngestor(unittest.TestCase):
         self.anndata_ingest.generate_cluster_header(
             self.anndata_ingest.obtain_adata(), self.cluster_name
         )
-        with open(self.output_filename) as header_file:
+        with open(self.cluster_filename) as header_file:
             header = header_file.readline().split("\t")
             self.assertEqual(
                 ['NAME', 'X', "Y\n"], header, "did not find expected headers"
@@ -82,7 +83,7 @@ class TestAnnDataIngestor(unittest.TestCase):
         self.anndata_ingest.generate_cluster_type_declaration(
             self.anndata_ingest.obtain_adata(), self.cluster_name
         )
-        with open(self.output_filename) as header_file:
+        with open(self.cluster_filename) as header_file:
             header = header_file.readline().split("\t")
             self.assertEqual(
                 ['TYPE', 'numeric', "numeric\n"],
@@ -94,7 +95,7 @@ class TestAnnDataIngestor(unittest.TestCase):
         self.anndata_ingest.generate_cluster_body(
             self.anndata_ingest.obtain_adata(), self.cluster_name
         )
-        with open(self.output_filename) as cluster_body:
+        with open(self.cluster_filename) as cluster_body:
             line = cluster_body.readline().split("\t")
             expected_line = ['AAACATACAACCAC-1', '16.009954', "-21.073845\n"]
             self.assertEqual(
@@ -103,9 +104,27 @@ class TestAnnDataIngestor(unittest.TestCase):
                 'did not get expected coordinates from cluster body',
             )
 
+    def test_generate_metadata_file(self):
+        self.anndata_ingest.generate_metadata_file(
+            self.anndata_ingest.obtain_adata(), self.metadata_filename
+        )
+        with open(self.metadata_filename) as metadata_body:
+            line = metadata_body.readline().split("\t")
+            expected_line = [
+                'NAME', 'n_genes', 'percent_mito', 'n_counts', 'louvain', 'donor_id', 'biosample_id', 'sex', 'species',
+                'species__ontology_label', 'disease', 'disease__ontology_label', 'organ', 'organ__ontology_label',
+                'library_preparation_protocol', "library_preparation_protocol__ontology_label\n"
+            ]
+            self.assertEqual(
+                expected_line,
+                line,
+                'did not get expected headers from metadata body',
+            )
+
+
     def test_get_files_to_delocalize(self):
         files = AnnDataIngestor.clusterings_to_delocalize(self.valid_kwargs)
-        expected_files = [self.output_filename]
+        expected_files = [self.cluster_filename]
         self.assertEqual(expected_files, files)
 
     def test_delocalize_files(self):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -696,6 +696,24 @@ class IngestTestCase(unittest.TestCase):
         filename = 'h5ad_frag.cluster.X_tsne.tsv'
         self.assertTrue(os.path.isfile(filename))
 
+    def test_extract_metadata_file_from_anndata(self):
+        args = [
+            "--study-id",
+            "5d276a50421aa9117c982845",
+            "--study-file-id",
+            "5dd5ae25421aa910a723a337",
+            "ingest_anndata",
+            "--ingest-anndata",
+            "--extract",
+            "['metadata']",
+            "--anndata-file",
+            "../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad",
+        ]
+        ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
+        self.assertEqual(len(status), 1)
+        self.assertEqual(status[0], 0)
+        filename = 'h5ad_frag.metadata.tsv'
+        self.assertTrue(os.path.isfile(filename))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This update adds test coverage for metadata extraction from h5ad files.  It also removes some now unused lines of code from `ingest_pipeline.py`.

### MANUAL TESTING
1. Set up test environment locally from the project root with:
```
python3 -m venv env --copies
source env/bin/activate
pip install -r requirements.txt
source scripts/setup_mongo_dev.sh <path to your Github token file>
```
2. Go to the test directory and run the associated tests (the first suite should run in ~2-3s, but the second will take a few minutes to complete):
```
cd tests
pytest test_anndata.py
pytest test_ingest.py
```
Note: you will see a large amount of warnings from both suites but there should be no failures:
```
test_anndata.py ..........                                                                                                           [100%]

==================== warnings summary ==================== 
tests/test_anndata.py::TestAnnDataIngestor::test_delocalize_files
tests/test_anndata.py::TestAnnDataIngestor::test_generate_cluster_body
tests/test_anndata.py::TestAnnDataIngestor::test_generate_cluster_header
tests/test_anndata.py::TestAnnDataIngestor::test_generate_cluster_type_declaration
...

==================== 10 passed, 360 warnings in 2.32 seconds ====================
```