### PR TITLE
Update ingest to use python3.8 (SCP-4547, SCP-4208)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            `python -m site --user-site` -m venv venv
+            python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            python3 -m venv venv
+            `python -m site --user-site` -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.5-stretch
+      - image: cimg/python:3.8
     resource_class: large
 
     working_directory: ~/scp-ingest-pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "requirements.txt" }}
+            - v4-dependencies-{{ checksum "requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v3-dependencies-
+            - v4-dependencies-
 
       - run:
           name: Install Python dependencies
@@ -36,7 +36,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v3-dependencies-{{ checksum "requirements.txt" }}
+          key: v4-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,6 @@ jobs:
             - v3-dependencies-
 
       - run:
-          name: Install system dependencies for Genomes Pipeline
-          command: |
-            sudo apt-get install -y tabix
-
-      - run:
           name: Install Python dependencies
           command: |
             python3 -m venv venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,18 @@ FROM marketplace.gcr.io/google/ubuntu1804:latest
 
 # RUN echo "Uncomment to clear cached layers below this statement (2020-01-07-0947)"
 
-# Install Python 3.7
+# Install Python 3.8
 RUN apt-get -y update && \
   apt-get -y install software-properties-common && \
   add-apt-repository ppa:deadsnakes/ppa && \
   apt-get -y install python3-pip && \
-  apt-get -y install python3.7 && \
-  apt-get -y install python3.7-dev
+  apt-get -y install python3.8 && \
+  apt-get -y install python3.8-dev
 
-RUN python3.7 -m pip install --upgrade pip
+RUN python3.8 -m pip install --upgrade pip
 
 # Set cleaner defaults (`alias` fails)
-RUN ln -s /usr/bin/python3.7 /usr/bin/python && \
+RUN ln -s /usr/bin/python3.8 /usr/bin/python && \
   ln -s /usr/bin/pip3 /usr/bin/pip
 
 # Copy contents of this repo into the Docker image
@@ -35,7 +35,7 @@ COPY . scp-ingest-pipeline
 WORKDIR /scp-ingest-pipeline
 
 # Install Python dependencies
-RUN python3.7 -m pip install -r requirements.txt
+RUN python3.8 -m pip install -r requirements.txt
 
 WORKDIR /scp-ingest-pipeline/ingest
 CMD ["python", "ingest_pipeline.py", "--help"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ google-cloud-storage==1.28.1
 google-cloud-bigquery==1.24.0
 grpcio==1.29.0
 requests==2.22.0
-numpy==1.21.5
-scipy==1.5.2
+numpy==1.22.3
+scipy==1.7.3
 jsonschema==3.0.1
 pandas==1.3.5
 pandocfilters==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pre-commit==1.18.1
 black==19.3b0
 flake8==3.7.8
 pytest-cov==2.8.1
+matplotlib==3.6.3
 
 # Don't add this until we actually support Zarr
 #zarr==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Moving ingest to python3.8 to enable developing on M1 Macs. Updating numpy/scipy in `requirements.txt` enables a working local python environment and requires Python 3.8 which caused build failures in CI due to Python 3.7.5.

This work migrates off CircleCI's [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) Legacy Convenience Image `circleci/python:3.7.5-stretch` to use `cimg/python:3.8`

Note for future Python updates: 
when switching convenience images, [increment the cache key name](https://discuss.circleci.com/t/upgrading-to-the-convenience-image-breaks-everything/42746) in `.circleci/config.yml`

QA design: automated
If this works, CI should build and test successfully.