### PR TITLE
Restore missing symlink to python in docker image (SCP-4547)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,8 @@ RUN apt-get -y update && \
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 
-# # Set cleaner defaults (`alias` fails)
-# RUN ln -s /usr/bin/python3.10 /usr/bin/python && \
-#   ln -s /usr/bin/pip3 /usr/bin/pip
+# symlink python3.10 to python
+RUN ln -s /usr/bin/python3.10 /usr/bin/python
 
 # Copy contents of this repo into the Docker image
 # (See .Dockerignore for omitted files)
@@ -36,7 +35,7 @@ COPY . scp-ingest-pipeline
 WORKDIR /scp-ingest-pipeline
 
 # Install Python dependencies
-RUN python3.10 -m pip install -r requirements.txt
+RUN python -m pip install -r requirements.txt
 
 WORKDIR /scp-ingest-pipeline/ingest
 CMD ["python", "ingest_pipeline.py", "--help"]

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ There are some extra steps required, but this sidesteps the need to install pack
 Run the following command to build the testing Docker image locally (make sure Docker is running first). This build command will incorporate any changes in the local instance of your repo, committed or not:
 
 ```
-docker build -t gcr.io/broad-singlecellportal-staging/ingest-pipeline:test-candidate .
+docker build -t ingest-pipeline:test-candidate .
 ```
 
-Note - if this is your first time doing `docker build` you may need to configure Docker to use the Google Cloud CLI to authenticate requests to Container Registry:
+Note - the base Ubuntu image used in the Dockerfile comes from Google Container Registry (GCR, aka gcr.io), if this is your first time doing `docker build` you may need to configure Docker to use the Google Cloud CLI to authenticate requests to Container Registry:
 
 ```
 gcloud auth configure-docker
@@ -163,7 +163,7 @@ Run the container, passing in the proper environment variables:
 docker run --name scp-ingest-test -e MONGODB_USERNAME="$MONGODB_USERNAME" -e DATABASE_NAME="$DATABASE_NAME" \
            -e MONGODB_PASSWORD="$MONGODB_PASSWORD" -e DATABASE_HOST="$DATABASE_HOST" \
            -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keyfile.json --rm -it \
-           gcr.io/broad-singlecellportal-staging/ingest-pipeline:test-candidate bash
+           ingest-pipeline:test-candidate bash
 ```
 
 Note: on an M1 machine, you may see this message:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandocfilters==1.4.2
 mypy-extensions==0.4.1
 dataclasses==0.6
 colorama==0.4.1
-pymongo==3.9.0
+pymongo==3.12.0
 backoff==1.10.0
 scanpy==1.9.2
 


### PR DESCRIPTION
Minor updates to `Dockerfile` and `requirements.txt` to fix broken ingest docker image:
- Restore missing symlink to python
- Update pymongo for python 3.10 breaking change (references: [PEP-0353](https://peps.python.org/pep-0353/) and [bpo-40943](https://github.com/python/cpython/pull/25937))

To test, follow README instructions for [Testing in Docker locally](https://github.com/broadinstitute/scp-ingest-pipeline/tree/jlc_fix_image#testing-in-docker-locally) Steps 1,2 & 4

Once in the docker container, set up to bypass the mongo database requirement:
`export BYPASS_MONGO_WRITES='yes'`

Test ingest of cluster and metadata files should succeed (despite unregistered study-id and study-file-id provided):

1. `python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_cell_metadata --cell-metadata-file ../tests/data/annotation/metadata/convention/valid_no_array_v2.0.0.txt --study-accession SCP123 --ingest-cell-metadata`
2. `python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_cluster --cluster-file ../tests/data/cluster_example.txt --ingest-cluster --name cluster1 --domain-ranges "{'x':[-1, 1], 'y':[-1, 1], 'z':[-1, 1]}"`

Test ingest of expression matrix file will fail (due to unregistered study-id and study-file-id provided) with:
> ValueError: Study ID is not registered with a study. Please provide a valid study ID.
Due to lack of database bypass mechanism for expression matrix ingests.

for reference, expression matrix ingest command:
`python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_expression --taxon-name 'Homo sapiens' --taxon-common-name human --ncbi-taxid 9606 --matrix-file ../tests/data/dense_matrix_19_genes_1000_cells.txt --matrix-file-type dense`

Expression matrix validity can be tested by pointing a portal core instance to an ingest docker image with a docker build from this PR (eg. gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_fix_image:e42abd1) and running the `test_create_default_testing_study` integration test:
`bin/run_tests.sh -l -t test/integration/study_creation_test.rb`