### PR TITLE
Refine mtx error messaging for transposed matrices (SCP-5073)

### DIFF
--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -161,6 +161,10 @@ class MTXIngestor(GeneExpression, IngestFiles):
             msg = (
                 f"Expected {expected_barcodes} cells and {expected_genes} genes. "
                 f"Got {actual_barcodes} cells and {actual_genes} genes."
+                f"Uploaded matrix suggests {actual_barcodes} cells and {actual_genes} genes "
+                f"instead of {expected_barcodes} cells and {expected_genes} genes. "
+                f"Please transpose your sparse matrix and re-upload. "
+                f"Transposition is expected for matrices exported from AnnData objects. "
             )
             GeneExpression.log_for_mixpanel(
                 "error", "format:cap:mtx-dimension-mismatch", msg

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -161,10 +161,10 @@ class MTXIngestor(GeneExpression, IngestFiles):
             actual_genes == expected_barcodes
         ):
             msg = (
-                f"Uploaded matrix suggests {actual_barcodes} cells and {actual_genes} genes "
+                f"Uploaded matrix suggests {actual_barcodes} columns and {actual_genes} rows "
                 f"instead of {expected_barcodes} cells and {expected_genes} genes. "
                 f"Please transpose your sparse matrix and re-upload. "
-                f"Transposition is expected for matrices exported from AnnData objects. "
+                f"Matrices exported from AnnData objects must be transposed."
             )
             GeneExpression.log_for_mixpanel(
                 "error", "format:cap:mtx-dimension-mismatch", msg

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -157,14 +157,24 @@ class MTXIngestor(GeneExpression, IngestFiles):
 
         if (actual_barcodes == expected_barcodes) and (actual_genes == expected_genes):
             return True
-        else:
+        elif (actual_barcodes == expected_genes) and (
+            actual_genes == expected_barcodes
+        ):
             msg = (
-                f"Expected {expected_barcodes} cells and {expected_genes} genes. "
-                f"Got {actual_barcodes} cells and {actual_genes} genes."
                 f"Uploaded matrix suggests {actual_barcodes} cells and {actual_genes} genes "
                 f"instead of {expected_barcodes} cells and {expected_genes} genes. "
                 f"Please transpose your sparse matrix and re-upload. "
                 f"Transposition is expected for matrices exported from AnnData objects. "
+            )
+            GeneExpression.log_for_mixpanel(
+                "error", "format:cap:mtx-dimension-mismatch", msg
+            )
+            raise ValueError(msg)
+        else:
+            msg = (
+                f"Expected {expected_barcodes} cells and {expected_genes} genes. "
+                f"Got {actual_barcodes} cells and {actual_genes} genes. "
+                f"Please check the files of your mtx bundle (barcode, feature, mtx) for errors."
             )
             GeneExpression.log_for_mixpanel(
                 "error", "format:cap:mtx-dimension-mismatch", msg

--- a/ingest/expression_files/mtx.py
+++ b/ingest/expression_files/mtx.py
@@ -162,7 +162,7 @@ class MTXIngestor(GeneExpression, IngestFiles):
         ):
             msg = (
                 f"Uploaded matrix suggests {actual_barcodes} columns and {actual_genes} rows "
-                f"instead of {expected_barcodes} cells and {expected_genes} genes. "
+                f"instead of {expected_barcodes} cells and {expected_genes} features/genes. "
                 f"Please transpose your sparse matrix and re-upload. "
                 f"Matrices exported from AnnData objects must be transposed."
             )

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -76,7 +76,7 @@ class TestMTXIngestor(unittest.TestCase):
             )
         expected_msg = (
             f"Uploaded matrix suggests {len(genes_as_barcodes)} columns and {len(barcodes_as_genes)} rows "
-            f"instead of {expected_barcodes} cells and {expected_genes} genes. "
+            f"instead of {expected_barcodes} cells and {expected_genes} features/genes. "
             f"Please transpose your sparse matrix and re-upload. "
             f"Matrices exported from AnnData objects must be transposed."
         )

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -65,6 +65,20 @@ class TestMTXIngestor(unittest.TestCase):
         )
         self.assertEqual(str(cm.exception), expected_msg)
 
+        genes_as_barcodes = [1, 2, 3, 4, 5]
+        barcodes_as_genes = ["cell0", "cell1", "cell3", "cell4"]
+        with self.assertRaises(ValueError) as cm:
+            MTXIngestor.check_bundle(
+                genes_as_barcodes, barcodes_as_genes, mtx_dimensions
+            )
+        expected_msg = (
+            f"Uploaded matrix suggests {len(genes_as_barcodes)} cells and {len(barcodes_as_genes)} genes "
+            f"instead of {expected_barcodes} cells and {expected_genes} genes. "
+            f"Please transpose your sparse matrix and re-upload. "
+            f"Transposition is expected for matrices exported from AnnData objects. "
+        )
+        self.assertEqual(str(cm.exception), expected_msg)
+
     def test_sort_mtx(self):
         import filecmp
         import os

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -75,10 +75,10 @@ class TestMTXIngestor(unittest.TestCase):
                 genes_as_barcodes, barcodes_as_genes, mtx_dimensions
             )
         expected_msg = (
-            f"Uploaded matrix suggests {len(genes_as_barcodes)} cells and {len(barcodes_as_genes)} genes "
+            f"Uploaded matrix suggests {len(genes_as_barcodes)} columns and {len(barcodes_as_genes)} rows "
             f"instead of {expected_barcodes} cells and {expected_genes} genes. "
             f"Please transpose your sparse matrix and re-upload. "
-            f"Transposition is expected for matrices exported from AnnData objects. "
+            f"Matrices exported from AnnData objects must be transposed."
         )
         self.assertEqual(str(cm.exception), expected_msg)
 
@@ -162,7 +162,6 @@ class TestMTXIngestor(unittest.TestCase):
         self.assertEqual("MTX file did not contain expression data.", str(cm.exception))
 
     def test_check_duplicates(self):
-
         values = ["2", "4", "5", "7"]
         self.assertTrue(MTXIngestor.check_duplicates(values, "scores"))
         dup_values = ["foo1", "f002", "foo1", "foo3"]
@@ -227,7 +226,7 @@ class TestMTXIngestor(unittest.TestCase):
         self, mock_load, mock_transform, mock_has_unique_cells, mock_is_raw_count_file
     ):
         """
-            Integration test for execute_ingest()
+        Integration test for execute_ingest()
         """
 
         expression_matrix = MTXIngestor(

--- a/tests/test_mtx.py
+++ b/tests/test_mtx.py
@@ -44,7 +44,8 @@ class TestMTXIngestor(unittest.TestCase):
             MTXIngestor.check_bundle(barcodes, gene_short, mtx_dimensions)
         expected_msg = (
             f"Expected {expected_barcodes} cells and {expected_genes} genes. "
-            f"Got {len(barcodes)} cells and {len(gene_short)} genes."
+            f"Got {len(barcodes)} cells and {len(gene_short)} genes. "
+            f"Please check the files of your mtx bundle (barcode, feature, mtx) for errors."
         )
         self.assertEqual(str(cm.exception), expected_msg)
 
@@ -53,7 +54,8 @@ class TestMTXIngestor(unittest.TestCase):
             MTXIngestor.check_bundle(barcodes_bad, genes, mtx_dimensions)
         expected_msg = (
             f"Expected {expected_barcodes} cells and {expected_genes} genes. "
-            f"Got {len(barcodes_bad)} cells and {len(genes)} genes."
+            f"Got {len(barcodes_bad)} cells and {len(genes)} genes. "
+            f"Please check the files of your mtx bundle (barcode, feature, mtx) for errors."
         )
         self.assertEqual(str(cm.exception), expected_msg)
 
@@ -61,7 +63,8 @@ class TestMTXIngestor(unittest.TestCase):
             MTXIngestor.check_bundle(barcodes_bad, gene_short, mtx_dimensions)
         expected_msg = (
             f"Expected {expected_barcodes} cells and {expected_genes} genes. "
-            f"Got {len(barcodes_bad)} cells and {len(gene_short)} genes."
+            f"Got {len(barcodes_bad)} cells and {len(gene_short)} genes. "
+            f"Please check the files of your mtx bundle (barcode, feature, mtx) for errors."
         )
         self.assertEqual(str(cm.exception), expected_msg)
 
@@ -201,7 +204,8 @@ class TestMTXIngestor(unittest.TestCase):
                 duplicate_barcodes, short_genes, [3, 3, 25], query_params
             )
         expected_msg = (
-            "Expected 3 cells and 3 genes. Got 3 cells and 2 genes.;"
+            f"Expected 3 cells and 3 genes. Got 3 cells and 2 genes. "
+            f"Please check the files of your mtx bundle (barcode, feature, mtx) for errors.;"
             f" {expected_dup_msg}"
         )
         self.assertEqual(expected_msg, str(cm.exception))
@@ -238,7 +242,8 @@ class TestMTXIngestor(unittest.TestCase):
             expression_matrix.execute_ingest()
         self.assertEqual(
             str(error.exception),
-            "Expected 25 cells and 33694 genes. Got 272 cells and 80 genes.",
+            f"Expected 25 cells and 33694 genes. Got 272 cells and 80 genes. "
+            f"Please check the files of your mtx bundle (barcode, feature, mtx) for errors.",
         )
         expression_matrix = MTXIngestor(
             "../tests/data/mtx/AB_toy_data_toy.matrix.mtx",


### PR DESCRIPTION
New study owner Sisi Sarkizova reached out in [Zendesk #308520](https://broadinstitute.zendesk.com/agent/tickets/308520) because she was unable to upload her mtx file successfully. In the team [Slack discussion](https://broadinstitute.slack.com/archives/CBEHTH601/p1681241822185889) we observed that the process could detect matrices that need transposition (but we cannot automagically transpose the data for the study owner because future users of the data would expect the mtx file to have its data transposed). We also noted that Sisi likely didn't see the error email so this change is non-blocking.

This PR adds a refined error message when a transposed matrix is detected and enhances the standard feature/cell count mismatch error message. The messaging is automatically tested in test_mtx with tests for non-transposed matrices updated to use the new standard error message and one test in `test_check_valid` for the new transposed matrix error message.

To manually run the automated tests:
1. cd to the `tests` directory
2. `pytest -k test_mtx` should succeed with no errors 