### PR TITLE
Bugfix for AnnData file upload with 3D clustering (SCP-5191)

### DIFF
--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -65,7 +65,8 @@ class AnnDataIngestor(GeneExpression, IngestFiles):
         dim = ['NAME', 'X', 'Y']
         clustering_dimension = adata.obsm[clustering_name].shape[1]
         if clustering_dimension == 3:
-            headers = dim.append('Z')
+            dim.append('Z') 
+            headers = dim
         elif clustering_dimension == 2:
             headers = dim
         elif clustering_dimension > 3:


### PR DESCRIPTION
The line to add the 'Z' dimension for a 3D clustering for an AnnData file being ingested is broken.

The line:
`headers = dim.append('Z')` is intended to set the headers variable to be the value of the array `dim` plus 'Z' for 3 dimensional clusterings. However, Python does not support this way of writing this, resulting in an error if a user tries to upload an AnnData file with a 3D clustering. This PR fixes that error.

You can test just running Python in your terminal and doing the following:

To see the error which results from the current code:

```
dim = ['NAME', 'X', 'Y']
headers = dim.append('Z')
'\t'.join(headers) + '\n'
```
you will see:

> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
> TypeError: can only join an iterable

To see that the 2D clusterings are fine:

```
dim2 = ['NAME', 'X', 'Y']
headers = dim2
'\t'.join(headers) + '\n'
```

Should print out:

> 'NAME\tX\tY\n'


To test out the solution:
```
dim2.append('Z')
headers = dim
'\t'.join(headers) + '\n'
```

should print out 

> 'NAME\tX\tY\tZ\n'