### PR TITLE
Resolved sorting issue of pairwise output files for author DE (SCP-5204)

### DIFF
--- a/ingest/author_de.py
+++ b/ingest/author_de.py
@@ -282,7 +282,7 @@ def check_group(names_dict, name):
 def sort_comparison(ls):
     """
     Naturally sort groups in a pairwise comparison; specially handle one-vs-rest
-    this should take in a combined name, such as B cells--CSN1S1 macrophages
+    this should take in a list of groups, such as ['B cells', 'CSN1S1 macrophages']
 
     https://en.wikipedia.org/wiki/Natural_sort_order
 

--- a/ingest/author_de.py
+++ b/ingest/author_de.py
@@ -81,10 +81,10 @@ class AuthorDifferentialExpression:
 
         Then final format should have type 0 type 1 in the title, and genes, logfoldchanges, qval, and mean as columns
         """
-        # for i in clean_val:
-        #     val_to_sort = [i[0], i[1]]
-        #     sorted_list = sort_comparison(val_to_sort)
-        #     i[0], i[1] = sorted_list
+        #for i in clean_val:
+        #    val_to_sort = [i[0], i[1]]
+        #    sorted_list = sort_comparison(val_to_sort)
+        #   i[0], i[1] = sorted_list
 
         names_dict = {}
         all_group = []
@@ -141,6 +141,12 @@ class AuthorDifferentialExpression:
 
             if "rest" in i:
                 i = i.split("--")[0]
+
+            else:
+                first_group = i.split("--")[0]
+                second_group = i.split("--")[1]
+                sorted_list = sort_comparison([first_group, second_group])
+                i = f'{sorted_list[0]}--{sorted_list[1]}'
 
             comparison = '--'.join([DifferentialExpression.sanitize_strings(group) for group in i.split('--')])
 
@@ -276,11 +282,12 @@ def check_group(names_dict, name):
 def sort_comparison(ls):
     """
     Naturally sort groups in a pairwise comparison; specially handle one-vs-rest
-    this should take in only a list of two, ex (type1 type2)
+    this should take in a combined name, such as B cells--CSN1S1 macrophages
 
     https://en.wikipedia.org/wiki/Natural_sort_order
 
     """
+
     if any(i.isdigit() for i in ls):
         sorted_arr = sorted(ls, key=lambda x: int("".join([i for i in x if i.isdigit()])))
         return sorted_arr

--- a/ingest/author_de.py
+++ b/ingest/author_de.py
@@ -81,10 +81,6 @@ class AuthorDifferentialExpression:
 
         Then final format should have type 0 type 1 in the title, and genes, logfoldchanges, qval, and mean as columns
         """
-        #for i in clean_val:
-        #    val_to_sort = [i[0], i[1]]
-        #    sorted_list = sort_comparison(val_to_sort)
-        #   i[0], i[1] = sorted_list
 
         names_dict = {}
         all_group = []


### PR DESCRIPTION
Added correct natural sorting to the final file names generated from author DE. This is necessary to ensure that results can be displayed in the UI/UX, since it is sorting dependent. 

**Before**, showing sorting issue (note especially the file All_Cells_UMAP--General_Celltype--eosinophils--CSN1S1_macrophages--study--wilcoxon.tsv):
<img width="503" alt="Screen Shot 2023-06-28 at 12 54 26 PM" src="https://github.com/broadinstitute/scp-ingest-pipeline/assets/96444785/35d143de-fa48-4506-acb5-860a5100ad94">

**After:**
<img width="581" alt="Screen Shot 2023-06-28 at 12 52 17 PM" src="https://github.com/broadinstitute/scp-ingest-pipeline/assets/96444785/3071b165-d464-4cf3-8ceb-2b5eac02b94a">

