### PR TITLE
Author DE: support Seurat and other formats, fix numerical groups (SCP-5296)

### DIFF
--- a/ingest/author_de.py
+++ b/ingest/author_de.py
@@ -15,6 +15,7 @@ from ingest_files import IngestFiles
 
 sanitize_string = DifferentialExpression.sanitize_string
 
+
 def sort_comparison(groups):
     """Naturally sort groups in a pairwise comparison; specially handle one-vs-rest
 
@@ -36,9 +37,9 @@ def sort_comparison(groups):
 
 def convert_seurat_findallmarkers_to_wide(data):
     """Convert from Seurat FindAllMarkers() format to SCP DE wide format
-
-    TODO (SCP-5296): Finish handling
     """
+
+    # Update columns to use SCP's expected names and order
     data = data.rename(columns={"cluster": "group", "gene": "genes"})
     data = data.astype({"group": "string"})
     data = data.assign(comparison_group="rest")
@@ -46,6 +47,7 @@ def convert_seurat_findallmarkers_to_wide(data):
         "genes", "group", "comparison_group", "avg_log2FC", "p_val_adj", "p_val", "pct.1", "pct.2"
     ]
     data = data[expected_header_order]
+
     wide_df = convert_long_to_wide(data)
     return wide_df
 
@@ -59,7 +61,7 @@ def convert_long_to_wide(data):
     data["combined"] = data["group"] + "--" + data["comparison_group"]
     frames = []
     # E.g.
-    # gene  group   comparison_group    log2foldchange  pvals_adj   qvals   mean    cat dog
+    # genes  group   comparison_group    log2foldchange  pvals_adj   qvals   mean    cat dog
     # metrics = ["log2foldchange", "pvals_adj", "qvals", "mean", "cat", "dog"]
     for metric in metrics:
         wide_metric = pd.pivot(data, index="genes", columns="combined", values=metric)

--- a/ingest/author_de.py
+++ b/ingest/author_de.py
@@ -75,9 +75,9 @@ def convert_long_to_wide(data):
     metrics = list(data.columns[3:])
     data["combined"] = data["group"] + "--" + data["comparison_group"]
     frames = []
-    # E.g.
-    # genes  group   comparison_group    log2foldchange  pvals_adj   qvals   mean    cat dog
-    # metrics = ["log2foldchange", "pvals_adj", "qvals", "mean", "cat", "dog"]
+    # Example headers from a hypothetical author DE file:
+    # genes  groups   comparison_groups    log2foldchanges  pvals_adj   qvals   means    cats dogs
+    # metrics = ["log2foldchanges", "pvals_adj", "qvals", "mean", "cat", "dog"]
     for metric in metrics:
         wide_metric = pd.pivot(data, index="gene", columns="combined", values=metric)
         wide_metric = wide_metric.add_suffix(f"--{metric}")

--- a/ingest/author_de.py
+++ b/ingest/author_de.py
@@ -15,19 +15,6 @@ from ingest_files import IngestFiles
 
 sanitize_string = DifferentialExpression.sanitize_string
 
-
-def check_group(names_dict, name):
-    """Helper function to return the comparison based on the comparison with the value
-
-    Takes in dictionary that stores all names, and given name
-
-    E.g. input type_2_type_3_mean returns type_2_type_3
-    """
-    for i in names_dict:
-        if name in names_dict[i]:
-            return i
-
-
 def sort_comparison(groups):
     """Naturally sort groups in a pairwise comparison; specially handle one-vs-rest
 
@@ -462,16 +449,16 @@ class AuthorDifferentialExpression:
         # comparison name: [[gene, logfoldchanges, qval, mean], [gene, logfoldchanges, qval, mean], ...]
         comparisons = comparisons_dict.keys()
         rows_by_comparison = dict.fromkeys(comparisons, [])
+
         for comparison_metrics in grouped_comparison_metrics:
             metric_values = []
             for comparison_metric in comparison_metrics:
 
                 # E.g. "B cells--CSN1S1 macrophages"
-                comparison = check_group(comparisons_dict, comparison_metric)
+                comparison = '--'.join(comparison_metric.split('--')[0:2])
 
                 # Numerical values for metric in this comparison
                 values = rest[comparison_metric].tolist()
-
                 metric_values.append(values)
 
             rows = metric_values

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -376,15 +376,36 @@ def create_parser():
     )
 
     parser_ingest_differential_expression.add_argument(
+        "--genes-header",
+        required=True,
+        help="Header used for gene names / symbols in DE file"
+    )
+
+    parser_ingest_differential_expression.add_argument(
+        "--group-header",
+        required=True,
+        help="Header used for group in DE file"
+    )
+
+    parser_ingest_differential_expression.add_argument(
+        "--comparison-group-header",
+        required=False,
+        help=(
+            "Header used for comparison group in DE file.  " +
+            "For pairwise comparisons.  Can omit if DE file is in one-vs-rest-only format."
+        )
+    )
+
+    parser_ingest_differential_expression.add_argument(
         "--size-metric",
         required=True,
-        help="Header used as size metric in DE file"
+        help='Header used as size metric in DE file, e.g. "logfoldchanges", "avg_log2FC", etc.'
     )
 
     parser_ingest_differential_expression.add_argument(
         "--significance-metric",
         required=True,
-        help="Header used as significance metric in DE file"
+        help='Header used as significance metric in DE file, e.g. "pvals_adj", "p_val_adj", etc.'
     )
 
     # AnnData subparsers

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -65,6 +65,7 @@ import re
 import sys
 import re
 from contextlib import nullcontext
+import traceback
 from typing import Dict, Generator, List, Tuple, Union
 from wsgiref.simple_server import WSGIRequestHandler  # noqa: F401
 from bson.objectid import ObjectId
@@ -557,20 +558,34 @@ class IngestPipeline:
     def calculate_author_de(self):
         """Run differential expression analysis"""
         try:
+            kwargs = self.kwargs
+            if "comparison_group" not in kwargs:
+                kwargs["comparison_group"] = None
+
+            # Map canonical DE headers to headers in actual DE file to
+            header_refmap = {
+                "genes": kwargs["genes_header"],
+                "group": kwargs["group_header"],
+                "comparison_group": kwargs["comparison_group_header"],
+                "size": kwargs["size_metric"],
+                "significance": kwargs["significance_metric"]
+            }
+
             author_de = AuthorDifferentialExpression(
-                self.kwargs["cluster_name"],
-                self.kwargs["annotation_name"],
-                self.kwargs["study_accession"],
-                self.kwargs["annotation_scope"],
-                self.kwargs["method"],
-                self.kwargs["differential_expression_file"],
-                self.kwargs["size_metric"],
-                self.kwargs["significance_metric"]
+                kwargs["cluster_name"],
+                kwargs["annotation_name"],
+                kwargs["study_accession"],
+                kwargs["annotation_scope"],
+                kwargs["method"],
+
+                kwargs["differential_expression_file"],
+                header_refmap
             )
             author_de.execute()
 
             # execute function as MAIN then create method to search for the files created, delocalize them to bucket as with de.py. adjust other places it needs to be called
         except Exception as e:
+            print(traceback.format_exc())
             log_exception(IngestPipeline.dev_logger, IngestPipeline.user_logger, e)
             return 1
         # ToDo: surface failed DE for analytics (SCP-4206)

--- a/tests/test_author_de.py
+++ b/tests/test_author_de.py
@@ -17,6 +17,14 @@ from author_de import AuthorDifferentialExpression
 class TestDifferentialExpression(unittest.TestCase):
 
     def test_execute(self):
+        header_refmap = {
+            'genes': 'genes',
+            'group': 'group',
+            'comparison_group': 'comparison_group',
+            'size': 'logfoldchanges',
+            'significance': 'qval'
+        }
+
         author_de = AuthorDifferentialExpression(
             'cluster_umap_txt',
             'General_Celltype',
@@ -24,8 +32,7 @@ class TestDifferentialExpression(unittest.TestCase):
             'study',
             'wilcoxon',
             '../tests/data/author_de/lfc_qval_scanpy-like.csv',
-            'logfoldchanges',
-            'qval'
+            header_refmap
         )
         author_de.execute()
 
@@ -56,6 +63,15 @@ class TestDifferentialExpression(unittest.TestCase):
 
         This order of "genes", "<size_metric>", "<significance_metric>" is needed by the UI.
         """
+
+        header_refmap = {
+            'genes': 'genes',
+            'group': 'group',
+            'comparison_group': 'comparison_group',
+            'size': 'avg_log2FC',
+            'significance': 'p_val_adj'
+        }
+
         author_de = AuthorDifferentialExpression(
             'cluster_umap_txt',
             'General_Celltype',
@@ -63,8 +79,7 @@ class TestDifferentialExpression(unittest.TestCase):
             'study',
             'wilcoxon',
             '../tests/data/author_de/pval_lfc_pvaladj_seurat-like.tsv',
-            'avg_log2FC',
-            'p_val_adj'
+            header_refmap
         )
         author_de.execute()
 
@@ -78,10 +93,17 @@ class TestDifferentialExpression(unittest.TestCase):
         expected_line_1 = '0	ACE2	0.04469246812	0.561922816	0.2722805917	0.7277194083	0.561922816	6'
         self.assertEqual(lines[1].strip(), expected_line_1)
 
-    def test_basic_size_and_significance(self):
+    def test_size_and_significance_validation(self):
         """Tests validation that file has specified size and significance headers
         """
         with pytest.raises(ValueError) as exc_info:
+            header_refmap = {
+                'genes': 'genes',
+                'group': 'group',
+                'comparison_group': 'comparison_group',
+                'size': 'OTHER_SIZE',
+                'significance': 'OTHER_SIGNIFICANCE'
+            }
             author_de = AuthorDifferentialExpression(
                 'cluster_umap_txt',
                 'General_Celltype',
@@ -89,12 +111,11 @@ class TestDifferentialExpression(unittest.TestCase):
                 'study',
                 'wilcoxon',
                 '../tests/data/author_de/pval_lfc_pvaladj_seurat-like.tsv',
-                'OTHER_SIZE',
-                'OTHER_SIGNIFICANCE'
+                header_refmap
             )
             author_de.execute()
 
-        expected_msg = "Column headers must include \"OTHER_SIZE\" and \"OTHER_SIGNIFICANCE\".  No such size or significance metrics found in headers: ['p_val', 'avg_log2FC', 'pct.1', 'pct.2', 'p_val_adj', 'cluster']"
+        expected_msg = "Column headers must include \"OTHER_SIZE\" and \"OTHER_SIGNIFICANCE\".  No such size or significance metrics found in headers: ['pct.2', 'pct.1', 'p_val_adj', 'p_val', 'cluster', 'avg_log2FC']"
         self.assertEqual(str(exc_info.value), expected_msg)
 
     def test_seurat_findallmarkers(self):
@@ -105,6 +126,14 @@ class TestDifferentialExpression(unittest.TestCase):
         # matches the first DE file uploaded to SCP by a real user.
         input_filename = 'seurat_findallmarkers_one-vs-rest.csv'
 
+        header_refmap = {
+            'genes': 'gene',
+            'group': 'cluster',
+            'comparison_group': 'None',
+            'size': 'avg_log2FC',
+            'significance': 'p_val_adj'
+        }
+
         author_de = AuthorDifferentialExpression(
             'cluster_umap_txt',
             'General_Celltype',
@@ -112,8 +141,7 @@ class TestDifferentialExpression(unittest.TestCase):
             'study',
             'wilcoxon',
             f'../tests/data/author_de/{input_filename}',
-            'avg_log2FC',
-            'p_val_adj'
+            header_refmap
         )
         author_de.execute()
 

--- a/tests/test_author_de.py
+++ b/tests/test_author_de.py
@@ -44,7 +44,7 @@ class TestDifferentialExpression(unittest.TestCase):
         with open(one_vs_rest_de_output_file) as f:
             lines = f.readlines()
         self.assertEqual(len(lines), 41, f"Expected 41 files in: {one_vs_rest_de_output_file}")
-        expected_line_0 = 'genes	logfoldchanges	qval	mean'
+        expected_line_0 = 'gene	logfoldchanges	qval	mean'
         self.assertEqual(lines[0].strip(), expected_line_0)
         expected_line_1 = '0	ACE2	0.9852699170700532	0.146924681159184	0.2277194082712261'
 
@@ -53,7 +53,7 @@ class TestDifferentialExpression(unittest.TestCase):
         with open(pairwise_de_output_file) as f:
             lines = f.readlines()
         self.assertEqual(len(lines), 41, f"Expected 41 files in: {pairwise_de_output_file}")
-        expected_line_0 = 'genes	logfoldchanges	qval	mean'
+        expected_line_0 = 'gene	logfoldchanges	qval	mean'
         self.assertEqual(lines[0].strip(), expected_line_0)
         expected_line_1 = '0	ACE2	0.685269917070053	0.446924681159184	0.727719408271226'
         self.assertEqual(lines[1].strip(), expected_line_1)
@@ -61,7 +61,7 @@ class TestDifferentialExpression(unittest.TestCase):
     def test_column_ordering(self):
         """Tests that processed output has specified size metric as 1st, significance as 2nd.
 
-        This order of "genes", "<size_metric>", "<significance_metric>" is needed by the UI.
+        This order of "gene", "<size_metric>", "<significance_metric>" is needed by the UI.
         """
 
         header_refmap = {
@@ -88,7 +88,7 @@ class TestDifferentialExpression(unittest.TestCase):
         with open(one_vs_rest_de_output_file) as f:
             lines = f.readlines()
         self.assertEqual(len(lines), 41, f"Expected 41 files in: {one_vs_rest_de_output_file}")
-        expected_line_0 = 'genes	avg_log2FC	p_val_adj	pct.2	pct.1	p_val	cluster'
+        expected_line_0 = 'gene	avg_log2FC	p_val_adj	pct.2	pct.1	p_val	cluster'
         self.assertEqual(lines[0].strip(), expected_line_0)
         expected_line_1 = '0	ACE2	0.04469246812	0.561922816	0.2722805917	0.7277194083	0.561922816	6'
         self.assertEqual(lines[1].strip(), expected_line_1)
@@ -149,7 +149,7 @@ class TestDifferentialExpression(unittest.TestCase):
         with open(output_file) as f:
             lines = [line.strip() for line in f.readlines()]
 
-        expected_line_0 = 'genes	avg_log2FC	p_val_adj	pct.2	pct.1	p_val'
+        expected_line_0 = 'gene	avg_log2FC	p_val_adj	pct.2	pct.1	p_val'
         expected_line_1 = '0	CRP	1.082893128	0.0	0.1364	0.3268	0.0'
         expected_line_2 = '1	LGALS3	1.399143463	0.0	0.29848	0.4284	0.0'
         expected_line_3 = '2	PIK3CA	0.7331456728	7.070000000000001e-273	0.34236	0.67932	3.49e-277'


### PR DESCRIPTION
_If you haven't, please first review #321_.

---

This adds author DE support for output from [Seurat's FindAllMarkers()](https://satijalab.org/seurat/articles/pbmc3k_tutorial.html#finding-differentially-expressed-features-cluster-biomarkers) function, which a user recently uploaded.

### Support Seurat and other formats
More generally, these changes implement flexible author DE headers to support _any_ long-header-format DE file uploaded by the user, extending [early parameterization under review](https://github.com/broadinstitute/scp-ingest-pipeline/pull/321).  This is achieved by removing hard-coded assumptions about the names and order of the input headers "gene", "group", and "comparison_group".  The "comparison_group" header is also now optional, easing upload of more-natively-formatted data from e.g. default Seurat analysis that _only_ contains one-vs-rest comparisons (and no pairwise comparisons).  

So, for example, this helps enable authors to upload not only Seurat FindAllMarkers() output -- which has a non-pairwise structure and headers that differ from our original expectations -- but _any_ DE file that isn't in wide format.  This means that if Seurat or Scanpy updates header strings they output, then author DE ingest won't break.  The headers for "gene", "group", and (if applicable) "comparison_group" will be provided by the author in the upload UI.  Specifying those header names will typically require no author effort, as they'll be inferred upon file selection [like "Size metric" and "Significance metric"](https://github.com/broadinstitute/single_cell_portal_core/pull/1874), instantly reviewable at a glance, and overridable in 2 clicks if needed.

The output files used by the DE UI remain the same as before.  

### Fix numerical groups
Finally, this also fixes a lurking bug with ingesting differential expression comparisons for groups that have numerical labels (but are indeed categorical).  Such groups are often seen in early e.g. Leiden or Louvain clustering analysis.  

For example, previously, author DE ingest had bugs if the annotation had groups like "0", "1", "2", "3", ..., "20".  DE output for groups like "10" and "11" would simply be missing, due to subtle non-robustness in the `check_group` function.  This bug could have also manifested beyond numerical labels, albeit less commonly. 

Now the bug is fixed.  Transformation is robust for author DE involving numerical groups.

### Test
Automated tests have been updated. To manually test:

Run:
> python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 ingest_differential_expression --annotation-name General_Celltype --annotation-type group --annotation-scope study --cluster-name cluster_umap_txt --study-accession SCPdev --ingest-differential-expression --differential-expression-file ../tests/data/author_de/seurat_findallmarkers_one-vs-rest.csv --method wilcoxon --genes-header gene --group-header cluster --comparison-group-header None --size-metric avg_log2FC --significance-metric p_val_adj; head cluster_umap_txt--General_Celltype--10--study--wilcoxon.tsv

Confirm you see:
```
	genes	avg_log2FC	p_val_adj	pct.2	pct.1	p_val
0	CRP	1.082893128	0.0	0.1364	0.3268	0.0
1	LGALS3	1.399143463	0.0	0.29848	0.4284	0.0
2	PIK3CA	0.7331456728	7.070000000000001e-273	0.34236	0.67932	3.49e-277
```

This satisfies SCP-5296.