### PR TITLE
Restore curl in Docker image; removed in upstream dependency (SCP-5359)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get -y update && \
   apt-get -y install python3.10-dev && \
   apt-get -y install python3.10-distutils
 
+RUN apt-get update && apt-get install curl
+
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 
 # symlink python3.10 to python

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y update && \
   apt-get -y install python3.10-dev && \
   apt-get -y install python3.10-distutils
 
-RUN apt-get update && apt-get install curl
+RUN apt-get -y update && apt-get -y install curl
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 


### PR DESCRIPTION
This fixes failing Google Cloud Build runs, which broke due to our Docker image's base dependency `marketplace.gcr.io/google/ubuntu2004:latest` having removing `curl`.

This relates to SCP-5359.