### PR TITLE
Fix issue with non-standard `fileLocation` URLs (SCP-5419)

### DIFF
--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -168,10 +168,7 @@ class OntologyRetriever:
                     self.cached_ontologies[convention_shortname] = convention_ontology
 
         if convention_ontology and metadata_ontology:
-            base_term_uri = '/'.join(metadata_ontology["config"]["fileLocation"].split('/')[:-1]) + '/'
-            # temporary workaround for invald baseURI returned from EBI OLS for NCBITaxon (SCP-2820)
-            if base_term_uri == "http://purl.obolibrary.org/obo/NCBITAXON_":
-                base_term_uri = "http://purl.obolibrary.org/obo/NCBITaxon_"
+            base_term_uri = get_ontology_file_location(metadata_ontology)
             query_iri = encode_term_iri(term, base_term_uri)
 
             term_url = convention_ontology["_links"]["terms"]["href"] + "/" + query_iri
@@ -322,6 +319,17 @@ def extract_terminal_pathname(url):
 def get_urls_for_property(convention, property_name):
     return convention["properties"][property_name]["ontology"].split(",")
 
+
+def get_ontology_file_location(ontology):
+    """Find and format fileLocation URL for running queries against an ontology
+    """
+    location = ontology["config"]["fileLocation"]
+    # issue with some ontologies (like GO) having non-standard fileLocation URLs
+    if 'extensions' in location:
+        location = location.replace(f"{ontology['ontologyId']}/extensions/", "")
+    if location == "http://purl.obolibrary.org/obo/NCBITAXON_":
+        location = "http://purl.obolibrary.org/obo/NCBITaxon_"
+    return location
 
 ######################## END ONTOLOGY RETRIVER DEFINITION #########################
 

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -329,7 +329,7 @@ def get_ontology_file_location(ontology):
         location = location.replace(f"{ontology['ontologyId']}/extensions/", "")
     if location == "http://purl.obolibrary.org/obo/NCBITAXON_":
         location = "http://purl.obolibrary.org/obo/NCBITaxon_"
-    return location
+    return '/'.join(location.split('/')[:-1]) + '/'
 
 ######################## END ONTOLOGY RETRIVER DEFINITION #########################
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes an issue where some ontologies in OLS have non-standard URLs for the `fileLocation` configuration (like `GO` having a value of `http://purl.obolibrary.org/obo/go/extensions/go-plus.owl`).  This URL is used in queries to validate terms, and can lead to terms that should validate not being found.

#### MANUAL TESTING
1. Download the `GO_terms.tsv` testing file from our [test data bucket](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/ols_testing/GO_terms.tsv;tab=live_object?project=broad-singlecellportal-staging)
2. Set up your local `scp-ingest-pipeline` environment, then run the command to ingest the file:
```
python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_cell_metadata --cell-metadata-file ~/Downloads/GO_terms.tsv --study-accession SCP123 --ingest-cell-metadata --validate-convention
```
3. Confirm there are no errors and that the process returned `success`:
```
...
distinct_id: 2f30ec50-a04d-4d43-8fd1-b136a2045079
studyAccession: SCPdev
fileName: 5dd5ae25421aa910a723a337
fileType: input_validation_bypassed
fileSize: 1
trigger: dev-mode
logger: ingest-pipeline
appId: single-cell-portal
status: success
functionName: ingest_cell_metadata
perfTime: 31.649
```