### PR TITLE
Increase server timeout, decrease DataArray batch to 500 (SCP-5429)

### DIFF
--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -33,7 +33,7 @@ except ImportError:
 class GeneExpression:
     __metaclass__ = abc.ABCMeta
     COLLECTION_NAME = "genes"
-    DATA_ARRAY_BATCH_SIZE = 1_000
+    DATA_ARRAY_BATCH_SIZE = 500
     # Logger provides more details
     dev_logger = setup_logger(__name__, "log.txt", format="support_configs")
 

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -34,6 +34,7 @@ class MongoConnection:
                 password=self.password,
                 authSource=self.db_name,
                 authMechanism="SCRAM-SHA-1",
+                serverSelectionTimeoutMS=60_000
             )
             self._client = client[self.db_name]
         # Needed to due to lack of database mock library for MongoDB


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Decreases `DataArray` batch size to `500` and increases `serverSelectionTimeoutMS` to 60s (amount of time to wait for server reconnect attempt).  Both are efforts to reduce the incidence of `Connection reset by peer` errors when ingesting very large expression matrices.  Longer timeout windows makes ingest more tolerant of disconnections, and decreasing the batch size should reduce the time it takes to insert and return, which should lower the probability of a disconnection happening.

#### MANUAL TESTING
Ingests through a local instance of SCP using [this large dense matrix slice](https://console.cloud.google.com/storage/browser/_details/broad-singlecellportal-staging-testing-data/large_matrix_files/chunk_0.tsv;tab=live_object?project=broad-singlecellportal-staging) (~3GB from a 110GB file, comprising 450 genes and 1.6M cells) were successful whereas similar runs with the latest release of ingest always failed.  If you would like to replicate this test, you can do so on staging by setting the Ingest Docker image to `gcr.io/broad-singlecellportal-staging/scp-ingest-jb-batch-size-decrease:ed1a9bb` and then ingesting the above matrix to a new study.