### PR TITLE
Index ATAC-seq fragment files, enabling visualization in igv.js (SCP-5529)

### DIFF
--- a/ingest/atac.py
+++ b/ingest/atac.py
@@ -2,6 +2,7 @@
 
 PREREQUISITE:
 - Install htslib: `brew install htslib` on macOS (TODO: Create Docker file)
+- Install bedtools: `brew install bedtools` on macOS (TODO: Create Docker file)
 
 """
 import os
@@ -20,12 +21,8 @@ def index_fragments(tsv_path):
     os.rename(tmp_tsv_path, bed_path)
 
     print("Sort BED file by genomic position")
-    # The "-k1.4V" argument ensures `sort` uses column "1" and breaks ties
-    # by ordering character "4" using version-sort, i.e. "V", which does a
-    # natural sort of (version) numbers within text.  This ensures e.g. "12"
-    # appears after "2".
     sorted_bed_path = bed_path.replace(".bed", ".possorted.bed")
-    sort_command = (f"sort -k1.4V {bed_path}").split(" ")
+    sort_command = (f"bedtools sort -i {bed_path}").split(" ")
     sorted_bed_file = open(sorted_bed_path, 'w')
     subprocess.call(sort_command, stdout=sorted_bed_file)
 
@@ -38,6 +35,8 @@ def index_fragments(tsv_path):
     # tabix creates an index for the tab-delimited files, used for getting small chunks
     tabix_command = (f"tabix -s 1 -b 2 -e 3 {sorted_bed_path}.gz").split(" ")
     subprocess.call(tabix_command)
+
+    print("Successfully indexed fragments file for visualization in igv.js")
 
 index_fragments("Library-8-20230710_atac.fragments.tsv")
 

--- a/ingest/atac.py
+++ b/ingest/atac.py
@@ -11,12 +11,13 @@ import subprocess
 def index_fragments(tsv_path):
     """Bgzip and TBI-index a raw ATAC-seq fragments file
     """
-    print("Index fragments file")
+    print("Index fragments file from DSP Pipelines team")
 
     print("Change suffix from .tsv to .bed, as expected by igv.js")
-    shutil.copy2(tsv_path, f"{tsv_path}.tmp") # Preserve original file
-    bed_path = tsv_path.replace(".tsv.tmp", ".bed")
-    os.rename(tsv_path, bed_path)
+    tmp_tsv_path = f"{tsv_path}.tmp"
+    shutil.copy2(tsv_path, tmp_tsv_path) # Preserve original file
+    bed_path = tmp_tsv_path.replace(".tsv.tmp", ".bed")
+    os.rename(tmp_tsv_path, bed_path)
 
     print("Sort BED file by genomic position")
     # The "-k1.4V" argument ensures `sort` uses column "1" and breaks ties

--- a/ingest/atac.py
+++ b/ingest/atac.py
@@ -1,0 +1,42 @@
+"""Process ATAC-seq files for visualization in igv.js
+
+PREREQUISITE:
+- Install htslib: `brew install htslib` on macOS (TODO: Create Docker file)
+
+"""
+import os
+import shutil
+import subprocess
+
+def index_fragments(tsv_path):
+    """Bgzip and TBI-index a raw ATAC-seq fragments file
+    """
+    print("Index fragments file")
+
+    print("Change suffix from .tsv to .bed, as expected by igv.js")
+    shutil.copy2(tsv_path, f"{tsv_path}.tmp") # Preserve original file
+    bed_path = tsv_path.replace(".tsv.tmp", ".bed")
+    os.rename(tsv_path, bed_path)
+
+    print("Sort BED file by genomic position")
+    # The "-k1.4V" argument ensures `sort` uses column "1" and breaks ties
+    # by ordering character "4" using version-sort, i.e. "V", which does a
+    # natural sort of (version) numbers within text.  This ensures e.g. "12"
+    # appears after "2".
+    sorted_bed_path = bed_path.replace(".bed", ".possorted.bed")
+    sort_command = (f"sort -k1.4V {bed_path}").split(" ")
+    sorted_bed_file = open(sorted_bed_path, 'w')
+    subprocess.call(sort_command, stdout=sorted_bed_file)
+
+    print("Compress sorted BED file with blocked gzip")
+     # bgzip enables requesting small indexed chunks of a gzip'd file
+    bgzip_command = (f"bgzip -kf {sorted_bed_path}").split(" ")
+    subprocess.call(bgzip_command)
+
+    print("Make a TBI index of the bgzipped BED file")
+    # tabix creates an index for the tab-delimited files, used for getting small chunks
+    tabix_command = (f"tabix -s 1 -b 2 -e 3 {sorted_bed_path}.gz").split(" ")
+    subprocess.call(tabix_command)
+
+index_fragments("Library-8-20230710_atac.fragments.tsv")
+


### PR DESCRIPTION
This prototypes a module to enable displaying indexed fragment files from the Pipelines team in IGV in a web browser.

### Test
1.  Download fragments file from [GCP bucket](https://console.cloud.google.com/storage/browser/fc-bcc55e6c-bec3-4b2e-9fb2-5e1526ddfcd2/reference_data_dev/nemo_atac/multiome_dsp_pipelines?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false)
2. Run `which bgzip` and `which tabix`, to check if you have those tools installed
3. If above output reports tools are already installed -- it'd print something like `/opt/homebrew/bin/tabix`. If step 2 commands return nothing -- then run `brew install htslib`
4. Re-run step 2 to confirm tools installed
5. `cd ingest`
6. `cp -p <fragments file from GCP bucket> .`
7. `python atac.py`
8. Run `ls -latr *bed*`
9. Confirm output includes .bed.gz and .bed.tbi files

More context is available in this week's [SCP demo recording](https://drive.google.com/file/d/1FNPSXTIQ1wWGPqFu4fA0B0TXgpPv68A3/view?t=23s), including how to visualize these in a standalone IGV web app.  This satisfies SCP-5529.