### PR TITLE
Remove all subsample thresholds below 100K (SCP-5702)

### DIFF
--- a/ingest/subsample.py
+++ b/ingest/subsample.py
@@ -17,7 +17,7 @@ except ImportError:
 class SubSample(Annotations):
     ALLOWED_FILE_TYPES = ["text/csv", "text/plain", "text/tab-separated-values"]
     MAX_THRESHOLD = 100_000
-    SUBSAMPLE_THRESHOLDS = [MAX_THRESHOLD, 20_000, 10_000, 1_000]
+    SUBSAMPLE_THRESHOLDS = [MAX_THRESHOLD]
 
     def __init__(self, cluster_file, cell_metadata_file=None):
         Annotations.__init__(self, cluster_file, self.ALLOWED_FILE_TYPES)

--- a/tests/test_subsample.py
+++ b/tests/test_subsample.py
@@ -32,6 +32,9 @@ class TestSubsample(unittest.TestCase):
         # This cluster file should be sampled at 1k
         self.subsample_obj = SubSample(self.CLUSTER_PATH)
 
+    def test_thresholds(self):
+        self.assertEqual([100000], self.subsample_obj.SUBSAMPLE_THRESHOLDS)
+
     def test_subsample(self):
         for data in self.subsample_obj.subsample("cluster"):
             header_value = data[1]


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This removes all subsampling thresholds below 100K for the `SubSample` module.  This will prevent generating smaller arrays that are no longer used in visualization purposes.  A forthcoming PR in [single_cell_portal_core](https://github.com/broadinstitute/single_cell_portal_core) will handle legacy data cleanup.

NOTE: there is currently an [issue on OLS](https://github.com/EBISPOT/ols4/issues/703) with the EFO ontology.  This will cause some metadata validation tests to fail.  This should be resolved by tomorrow evening.

#### MANUAL TESTING
The simplest way to test is to show that there is only the 100K threshold available.  The forthcoming PR in  [single_cell_portal_core](https://github.com/broadinstitute/single_cell_portal_core) will have a manual integration test to show that only the 100K subsamples are generated.
1. [Initialize virtual environment](https://github.com/broadinstitute/scp-ingest-pipeline?tab=readme-ov-file#native) and go to the `ingest` directory, then open a Python shell
2. Import the `SubSample` module and show that there is only the 100K threshold available:
```
>>> from subsample import SubSample
>>> SubSample.SUBSAMPLE_THRESHOLDS
[100000]
```