### PR TITLE
Cell Annotation Service: proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ errors.txt
 info.txt
 log.txt
 user_log.txt
+
+ingest/.cas-api-token

--- a/ingest/cas.py
+++ b/ingest/cas.py
@@ -1,0 +1,26 @@
+"""Cell Annotation Service (CAS) ETL for Single Cell Portal
+
+Context: https://github.com/broadinstitute/scp-ingest-pipeline/pull/353
+"""
+
+from cellarium.cas import CASClient
+
+# TODO (SCP-5715):
+# - Add CAS API token to Google Secrets Manager
+# - Update block below to use GSM
+# - Ensure team removes any local .cas-api-token files and .gitignore entry
+with open(".cas-api-token") as f:
+    api_token = f.read().strip()
+
+cas = CASClient(api_token=api_token)
+
+# Cavaet: processed expression values, as in this normalized / filtered 10x h5 file,
+# are not suitable for CAS.  The current code is only intended as a "Hello World".
+# The corresponding, commented-out "raw" 10x h5 file below would be best, but only
+# if refined to not have ~600K cells analyzed by CAS.
+h5_10x_path = "pbmc_unsorted_3k_filtered_feature_bc_matrix.h5"
+
+# h5_10x_path = "pbmc_unsorted_3k_raw_feature_bc_matrix.h5"
+
+response = cas.annotate_matrix_cell_type_summary_statistics_strategy(h5_10x_path)
+print(response)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,9 @@ colorama==0.4.1
 pymongo==4.6.3
 backoff==1.10.0
 scanpy==1.9.2
-anndata==0.9.1
+anndata==0.8.0
 ftfy==6.2.0
+cellarium-cas==1.4.6
 
 # Dev dependencies
 pytest==7.2.1


### PR DESCRIPTION
This is a "Hello World" for Cellarium CAS in SCP.  [Cell Annotation Service](https://www.cellarium.ai/tool/cellarium-cell-annotation-service-cas/) is a powerful, convenient way to assign cell types.

The simple kernel here demonstrates basic CAS-SCP plumbing.  The CAS [quickstart_tutorial.ipyb](https://github.com/cellarium-ai/cellarium-cas/blob/main/notebooks/quickstart_tutorial.ipynb), [repo](https://github.com/cellarium-ai/cellarium-cas), and [docs](https://cellarium-cas.readthedocs.io/) are useful resources.

### Test
The manual test below is especially optional, and mainly for reference.  Until we set up Google Secrets Manager (GSM) here, you'll need to use your own CAS API token.  It's easy to get, but turnaround might not be instant.

1. Get a CAS API token.  Visit https://cellarium.ai/tool/cellarium-cell-annotation-service-cas, scroll to bottom, sign up.  
2. Create a file `.cas-api-token` in `scp-ingest-pipeline/ingest/`, paste token, save
3.  Download https://cf.10xgenomics.com/samples/cell-arc/2.0.0/pbmc_unsorted_3k/pbmc_unsorted_3k_filtered_feature_bc_matrix.h5 to `scp-ingest-pipeline/ingest/`
4. `pip install -r requirements.txt`
5. `cd ingest`
6. `python cas.py`
7. Confirm you see output like:

```
* [09:40:49.644] Connecting to the Cellarium Cloud backend with session 94700f52-f5fb-4c25-87a1-18fb26e0d9bd...
* [09:40:50.011] User is eweitz
* [09:40:51.552] Authenticated in Cellarium Cloud v. 1.4.4
* [09:40:51.552] Allowed model list in Cellarium CAS:
  - cellarium-pca-default-v1 (default)
    Description: 64 dimensional PCA Model trained with library size normalization, log1p, zscore with a highly variable gene selection.
    Schema: refdata-gex-GRCh38-2020-A
    Embedding dimension: 64

* [09:40:52.663] Cellarium CAS (Model ID: cellarium-pca-default-v1)
* [09:40:52.664] Total number of input cells: 3009
* [09:40:55.960] The input data matrix has 81156 extra features compared to 'refdata-gex-GRCh38-2020-A' CAS schema (36601). Extra input features will be dropped.
* [09:40:56.429] Submitting cell chunk # 1 (    0,  1000) to CAS ...
* [09:40:56.820] Submitting cell chunk # 2 ( 1000,  2000) to CAS ...
* [09:40:57.200] Submitting cell chunk # 3 ( 2000,  3000) to CAS ...
* [09:40:57.576] Submitting cell chunk # 4 ( 3000,  3009) to CAS ...
* [09:41:08.708] Received the result for cell chunk # 4 ( 3000,  3009) ...
* [09:41:55.868] Received the result for cell chunk # 1 (    0,  1000) ...
* [09:41:58.094] Received the result for cell chunk # 2 ( 1000,  2000) ...
* [09:41:58.510] Received the result for cell chunk # 3 ( 2000,  3000) ...
* [09:41:58.512] Total wall clock time:    65.8488 seconds
[{'query_cell_id': 'AAACAGCCAACAGGTG-1', 'matches': [{'cell_type': 'T cell', 'cell_count': 170, 'min_distance': 0.03323555, 'p25_distance': 0.051376402, 'median_distance': 0.056035578, 'p75_distance': 
```
* See Slack for a convenient reference of the [full CAS response](https://broadinstitute.slack.com/archives/CBEHTH601/p1721839074040639).

### Further details 
More context is available in [2024-07-23 SCP demo slides](https://docs.google.com/presentation/d/1HhsMFf5M46LGClY341LWi1OkfZvWzT-eboZeiMN7kc8/edit) and [video](https://drive.google.com/file/d/1XUOUVuBPSMsOp5dgVZMtOZAlb_LC_aif/view?t=16m08s).  This satisfies SCP-5709.