### PR TITLE
Fix cluster query during AnnData subsampling (SCP-5140)

### DIFF
--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -284,6 +284,11 @@ class IngestPipeline:
                     "study_id": ObjectId(self.study_id),
                     "study_file_id": ObjectId(self.study_file_id),
                 }
+                # if this is an AnnData file, we need to append in the cluster name, otherwise studies with
+                # multiple clusters will not be able to subsample as the first cluster will be found each time
+                if config.study_file.file_type == "AnnData":
+                    query["name"] = self.name
+
                 # Query mongo for linear_id and 'name' of parent
                 # Then return 'name' and 'id' fields from query results
                 parent_data = self.db[parent_collection_name].find_one(

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -280,16 +280,7 @@ class IngestPipeline:
                 annot_name = subsampled_data[1][0]
                 annot_type = subsampled_data[1][1]
                 sample_size = subsampled_data[2]
-                query = {
-                    "study_id": ObjectId(self.study_id),
-                    "study_file_id": ObjectId(self.study_file_id),
-                }
-
-                # if this is an AnnData file, we need to append in the cluster name, otherwise studies with
-                # multiple clusters will not be able to subsample as the first cluster will be found each time
-                file_type = config.get_metric_properties().get_properties().get('fileType')
-                if file_type and file_type == "AnnData":
-                    query["name"] = self.kwargs.get("name")
+                query = self.get_cluster_query()
 
                 # Query mongo for linear_id and 'name' of parent
                 # Then return 'name' and 'id' fields from query results
@@ -318,6 +309,21 @@ class IngestPipeline:
             log_exception(IngestPipeline.dev_logger, IngestPipeline.user_logger, e)
             return 1
         return 0
+
+    def get_cluster_query(self):
+        """Generate MongoDB query to load ClusterGroup to set association IDs when subsampling"""
+        query = {
+            "study_id": ObjectId(self.study_id),
+            "study_file_id": ObjectId(self.study_file_id),
+        }
+
+        # if this is an AnnData file, we need to append in the cluster name, otherwise AnnData studies with
+        # multiple clusters will fail subsampling as the first cluster is always returned from the query
+        file_type = config.get_metric_properties().get_properties().get('fileType')
+        if file_type and file_type == "AnnData":
+            query["name"] = self.kwargs.get("name")
+
+        return query
 
     def upload_metadata_to_bq(self):
         """Uploads metadata to BigQuery"""

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -284,9 +284,11 @@ class IngestPipeline:
                     "study_id": ObjectId(self.study_id),
                     "study_file_id": ObjectId(self.study_file_id),
                 }
+
                 # if this is an AnnData file, we need to append in the cluster name, otherwise studies with
                 # multiple clusters will not be able to subsample as the first cluster will be found each time
-                if config.study_file.file_type == "AnnData":
+                file_type = config.get_metric_properties().get_properties().get('fileType')
+                if file_type and file_type == "AnnData":
                     query["name"] = self.name
 
                 # Query mongo for linear_id and 'name' of parent

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -289,7 +289,7 @@ class IngestPipeline:
                 # multiple clusters will not be able to subsample as the first cluster will be found each time
                 file_type = config.get_metric_properties().get_properties().get('fileType')
                 if file_type and file_type == "AnnData":
-                    query["name"] = self.name
+                    query["name"] = self.kwargs.get("name")
 
                 # Query mongo for linear_id and 'name' of parent
                 # Then return 'name' and 'id' fields from query results


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update fixes a bug in subsampling where a query to load the parent cluster group for setting association IDs (via `linear_data_id`) always returned the first clustering object.  Normally, this is not a problem as there is a 1:1 relationship between files and clustering objects, but AnnData files can have multiple.  As such, any user trying to extract multiple clusterings would always fail during subsampling.  Now, the query will correctly specify the clustering by name if the file is AnnData.

#### MANUAL TESTING
The simplest way to test this is to actually let ingest query your MongoDB instance.  Additionally, you will need the study_id and id of an AnnData file from your database.  To get this, you can open a Rails console session and run the following query (it doesn't matter if this a reference file or not):
```
StudyFile.where(file_type: 'AnnData').pluck(:study_id, :id).first
```
Then, setup your ingest environment as normal, but before entering a Python shell make sure to unset the MongoDB bypass with:
```
unset BYPASS_MONGO_WRITES
```
1. Once initialized, go to the `ingest` directory and open a Python interactive shell
2. Set up imports:
```
import config
from ingest_pipeline import IngestPipeline
from cli_parser import create_parser
```
3. Initialize your config:
```
study_id = "<id of study>"
study_file_id = "<id of AnnData file>"
config.init(study_id, study_file_id)
```
4. Create valid arguments and instantiate an `IngestPipeline` object:
```
opts = [
  "--study-id", study_id, "--study-file-id", study_file_id, "ingest_subsample", 
  "--cluster-file", "foo.txt", "--subsample", "--name", "UMAP"
]
args = create_parser().parse_args(opts)
arguments = vars(args)
ingest = IngestPipeline(**arguments)
```
5. Get the query object that would be used during subsampling and confirm that the `name` field has been added with the correct value of `UMAP` (your IDs will be different):
```
>>> ingest.get_cluster_query()
{'study_id': ObjectId('6696b8e494ec8f15a08dd627'), 'study_file_id': ObjectId('66b12ac32361e48b542bc7cd'), 'name': 'UMAP'}


```