### PR TITLE
Replacing vault with GSM for local development (SCP-5716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ cd scp-ingest-pipeline
 python3 -m venv env --copies
 source env/bin/activate
 pip install -r requirements.txt
-scripts/setup-mongo-dev.sh <PATH_TO_YOUR_VAULT_TOKEN> # E.g. ~/.github-token
+source scripts/setup-mongo-dev.sh
 ```
 
 ### Docker
 
-With Docker running and Vault active on your local machine, run:
+With Docker running and `gcloud` authenticated on your local machine, run:
 
 ```
-scripts/docker-compose-setup.sh -t <PATH_TO_YOUR_VAULT_TOKEN> # E.g. ~/.github-token
+scripts/docker-compose-setup.sh
 ```
 
 If on Apple silicon Mac (e.g. M1), and performance seems poor, consider generating a docker image using the arm64 base. Example test image: gcr.io/broad-singlecellportal-staging/single-cell-portal:development-2.2.0-arm64, usage:
 
 ```
-scripts/docker-compose-setup.sh -i development-2.2.0-arm64 -t <PATH_TO_YOUR_VAULT_TOKEN>
+scripts/docker-compose-setup.sh -i development-2.2.0-arm64
 ```
 
 To update dependencies when in Docker, you can pip install from within the Docker Bash shell after adjusting your requirements.txt.
@@ -132,10 +132,10 @@ Pro-Tip: For local builds, you can try adding docker build options `--progress=p
 
 ### 2. Set up environment variables
 
-Run the following to pull database-specific secrets out of vault (passing in the path to your vault token):
+Run the following to pull database-specific secrets out of Google Secrets Manager (GSM):
 
 ```
-source scripts/setup-mongo-dev.sh ~/.your-vault-token
+source scripts/setup-mongo-dev.sh
 ```
 
 Now run `env` to make sure you've set the following values:
@@ -152,7 +152,8 @@ DATABASE_HOST=<ip address>
 Run the following to export out your default service account JSON keyfile:
 
 ```
-vault read -format=json secret/kdux/scp/development/$(whoami)/scp_service_account.json | jq .data > /tmp/keyfile.json
+GOOGLE_PROJECT=$(gcloud info --format="value(config.project)")
+gcloud secrets versions access latest --project=$GOOGLE_PROJECT --secret=default-sa-keyfile | jq > /tmp/keyfile.json
 ```
 
 ### 4. Start the Docker container

--- a/ingest/monitor.py
+++ b/ingest/monitor.py
@@ -135,7 +135,7 @@ def integrate_sentry():
     if sentry_DSN is None:
         # Don't log to Sentry unless its DSN is set.
         # This disables Sentry logging in development and test (i.e.,
-        # environments without a SENTRY_DSN in their scp_config vault secret).
+        # environments without a SENTRY_DSN in their scp-config-json GSM secret).
         return
 
     sentry_logging = LoggingIntegration(

--- a/ingest/monitor.py
+++ b/ingest/monitor.py
@@ -129,7 +129,7 @@ def integrate_sentry():
     See also: links to Sentry resources atop this module
     """
 
-    # Ultimately stored in Vault, passed in as environmen variable to PAPI
+    # Ultimately stored in GSM, passed in as environment variable to PAPI
     sentry_DSN = os.environ.get("SENTRY_DSN")
 
     if sentry_DSN is None:

--- a/scripts/docker-compose-setup.sh
+++ b/scripts/docker-compose-setup.sh
@@ -10,22 +10,17 @@ usage=$(
 cat <<EOF
 $0 [OPTION]
 -i   Set URL for GCR image; helpful if not using latest development
--t   Set GitHub Vault token (e.g. ~/.github-token)
 -h   print this text
 EOF
 )
 
 GCR_IMAGE=""
 VAULT_TOKEN_PATH=""
-while getopts "i:t:h" OPTION; do
+while getopts "i:h" OPTION; do
 case $OPTION in
   i)
     echo "### SETTING GCR IMAGE ###"
     export GCR_IMAGE="$OPTARG"
-    ;;
-  t)
-    echo "### SETTING VAULT TOKEN ###"
-    VAULT_TOKEN_PATH="$OPTARG"
     ;;
   h)
   	echo "$usage"
@@ -45,13 +40,8 @@ if [[ $GCR_IMAGE = "" ]]; then
   export GCR_IMAGE="${IMAGE_NAME}:${LATEST_TAG}"
 fi
 
-if [[ $VAULT_TOKEN_PATH = "" ]]; then
-  echo "Did not provide VAULT_TOKEN_PATH"
-  exit 1
-fi
-
 echo "### SETTING UP ENVIRONMENT ###"
-./scripts/ingest-local-setup.sh $VAULT_TOKEN_PATH
+./scripts/ingest-local-setup.sh
 
 docker pull $GCR_IMAGE
 

--- a/scripts/setup-mongo-dev.sh
+++ b/scripts/setup-mongo-dev.sh
@@ -1,31 +1,18 @@
 #! /bin/bash
 
-# PREREQUISITE
-# Set up your GitHub token in a file for use to access Vault
-#
 # To set up your development environment before running ingest pipeline on the command line, run:
-# source setup-mongo-dev.sh <path to your GitHub token file>
+# source setup-mongo-dev.sh
 #
 # Keep "Dev env vars" synced with `ingest-local-setup.bash`
 
-VAULT_TOKEN_PATH="$1"
-if [[ -z "$VAULT_TOKEN_PATH" ]]
-then
-  echo "You must provide a path to a GitHub token to proceed"
-  exit 1
-fi
-vault login -method=github token=$(cat $VAULT_TOKEN_PATH)
-if [[ $? -ne 0 ]]
-then
-  echo "Unable to authenticate into vault"
-  exit 1
-fi
+GOOGLE_PROJECT=$(gcloud info --format="value(config.project)")
+MONGODB_PASSWORD=$(gcloud secrets versions access latest --project=$GOOGLE_PROJECT --secret=mongo-user | jq .password)
+DATABASE_HOST=$(gcloud secrets versions access latest --project=$GOOGLE_PROJECT --secret=mongo-hostname| jq -r '.ip[0]')
 
 # Dev env vars
-export BROAD_USER=`whoami`
 export MONGODB_USERNAME='single_cell'
 export DATABASE_NAME='single_cell_portal_development'
-export MONGODB_PASSWORD=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/user | grep password | awk '{ print $2 }' `
-export DATABASE_HOST=`vault read secret/kdux/scp/development/$BROAD_USER/mongo/hostname | grep ip | awk '{ $2=substr($2,2,length($2)-2); print $2 }' `
+export MONGODB_PASSWORD=$MONGODB_PASSWORD
+export DATABASE_HOST=$DATABASE_HOST
 export BYPASS_MONGO_WRITES='yes'
 export BARD_HOST_URL="https://terra-bard-dev.appspot.com"

--- a/scripts/setup-mongo-dev.sh
+++ b/scripts/setup-mongo-dev.sh
@@ -7,7 +7,7 @@
 
 GOOGLE_PROJECT=$(gcloud info --format="value(config.project)")
 MONGODB_PASSWORD=$(gcloud secrets versions access latest --project=$GOOGLE_PROJECT --secret=mongo-user | jq .password)
-DATABASE_HOST=$(gcloud secrets versions access latest --project=$GOOGLE_PROJECT --secret=mongo-hostname| jq -r '.ip[0]')
+DATABASE_HOST=$(gcloud secrets versions access latest --project=$GOOGLE_PROJECT --secret=mongo-hostname | jq -r '.ip[0]')
 
 # Dev env vars
 export MONGODB_USERNAME='single_cell'

--- a/scripts/vault-gsm-migration.sh
+++ b/scripts/vault-gsm-migration.sh
@@ -1,0 +1,119 @@
+#! /bin/bash
+
+# vault-gsm-migration.sh
+# script to pull out a single ingest-related secret from vault and import it into Google Secret Manager (GSM)
+# requires gcloud, vault, and jq to be installed and configured
+# adapted from https://github.com/broadinstitute/single_cell_portal_core/blob/development/bin/vault-gsm-migration.sh
+
+function authenticate_vault {
+  TOKEN_PATH="$1"
+  vault login -method=github token="$(cat "$TOKEN_PATH")"
+}
+
+function extract_secret_from_vault {
+  SECRET_PATH="$1"
+  vault read -field=data -format=json "$SECRET_PATH" | jq
+}
+
+function delete_gsm_secret {
+  SECRET_NAME="$1"
+  gcloud secrets delete "$SECRET_NAME" --quiet
+}
+
+function copy_secret_to_gsm {
+  VAULT_PATH="$1"
+  SECRET_NAME="$2"
+  GOOGLE_PROJECT="$3"
+  extract_secret_from_vault "$VAULT_PATH" | gcloud secrets create "$SECRET_NAME" --project="$GOOGLE_PROJECT" \
+                                            --replication-policy=automatic --data-file=-
+}
+
+function exit_with_error {
+  echo "### ERROR: $1 ###"
+  exit 1
+}
+
+function main {
+  GOOGLE_PROJECT=$(gcloud info --format="value(config.project)")
+  BASEPATH="secret/kdux/scp/development/$(whoami)"
+  VAULT_SECRET=""
+  ROLLBACK="false"
+  while getopts "t:p:b:s:rh" OPTION; do
+    case $OPTION in
+      t)
+        VAULT_TOKEN="$OPTARG"
+        ;;
+      p)
+        GOOGLE_PROJECT="$OPTARG"
+        echo "setting GOOGLE_PROJECT to $GOOGLE_PROJECT"
+        ;;
+      b)
+        BASEPATH="$OPTARG"
+        echo "setting BASEPATH to $BASEPATH"
+        ;;
+      s)
+        VAULT_SECRET="$OPTARG"
+        echo "setting VAULT_SECRET to $VAULT_SECRET"
+        ;;
+      r)
+        ROLLBACK="true"
+        ;;
+      h)
+        echo "$usage"
+        exit 0
+        ;;
+      *)
+        echo "unrecognized option"
+        echo "$usage"
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$VAULT_SECRET" ]]; then
+    echo "ERROR: Did not provide relative path to vault secret to copy"
+    echo "$usage"
+    exit 1
+  fi
+
+  # set up for GSM secret based on existing vault path
+  # changes / to -, e.g. mongo/hostname becomes mongo-hostname
+  GSM_SECRET_NAME=$(echo "$VAULT_SECRET" | sed 's/\//\-/g')
+
+  if [[ "$ROLLBACK" = "true" ]]; then
+    echo "Rolling back GSM migration"
+    echo -n "Deleting $VAULT_SECRET... "
+    delete_gsm_secret "$GSM_SECRET_NAME"
+    echo "Rollback complete!"
+    exit 0
+  fi
+
+  # construct vault path
+  VAULT_SECRET_PATH="$BASEPATH/$VAULT_SECRET"
+
+  authenticate_vault "$VAULT_TOKEN" || exit_with_error "cannot authenticate into vault"
+
+  echo -n "Copying $VAULT_SECRET from vault... "
+  copy_secret_to_gsm "$VAULT_SECRET_PATH" "$GSM_SECRET_NAME" "$GOOGLE_PROJECT" || exit_with_error "failed to copy $VAULT_SECRET"
+
+  echo "Secret migrated to GSM"
+  exit 0
+}
+
+usage=$(
+cat <<EOF
+USAGE:
+  $(basename "$0") -t VAULT_TOKEN -s VAULT_SECRET [<options>]
+
+  -t VAULT_TOKEN  set the path to token used to authenticate into vault (no default)
+  -s VAULT_SECRET set the name of the requested secret in vault to copy (no default)
+
+  [OPTIONS]
+  -p PROJECT      set the GCP project in which to create secrets (defaults to '$(gcloud info --format="value(config.project)")')
+  -b BASEPATH     set the base vault path for retrieving secrets (defaults to 'secret/kdux/scp/development/$(whoami)')
+  -r              roll back migration and delete scp-ingest-pipeline secret in GSM
+  -h              print this message
+EOF
+)
+
+main "$@"


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This replaces all existing Vault integration with Google Secrets Manager (GSM).  Similar to [this PR](https://github.com/broadinstitute/single_cell_portal_core/pull/2049) in `single_cell_portal_core`, a migration script has been added to copy relevant secrets out of Vault and into GSM.  However, since the aforementioned PR moved some of the required data already, this new migration script is agnostic and will allow the user to copy or roll back a single provided secret, rather than multiple hard-coded ones.  Additionally, all READMEs and local setup scripts for native Python or Docker have been updated to reference this new architecture.

#### MANUAL TESTING
1. If you are not authenticated into gcloud, run `gcloud auth login` and make sure you have your development SCP GCP project loaded:
```
gcloud info --format="value(config.project)" # should return broad-singlecellportal-{broad username}
```
2. Pull branch and the run the migration script to copy `mongo/hostname` over to GSM:
```
scripts/vault-gsm-migration.sh -t <path to your vault token> -s mongo/hostname
```
3. Once completed, run `source scripts/setup-mongo-dev.sh`
4. Run `env` and ensure values for `DATABASE_HOST` and `MONGODB_PASSWORD` have been set
5. (Optional) Start Docker Desktop, then run the two setup scripts to validate you get a running Docker container with the latest version of development:
```
scripts/ingest-local-setup.sh && scripts/docker-compose-setup.sh
```