### PR TITLE
Ingest raw count cells for AnnData files (SCP-5103)

### DIFF
--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -15,19 +15,19 @@ class MMFileFixedFormat(MMFile):
 
 
 try:
-    from ingest_files import IngestFiles
+    from ingest_files import DataArray, IngestFiles
     from expression_files.expression_files import GeneExpression
-    from monitor import log_exception
+    from monitor import log_exception, bypass_mongo_writes
     from validation.validate_metadata import list_duplicates
 except ImportError:
     # Used when importing as external package, e.g. imports in single_cell_portal code
-    from .ingest_files import IngestFiles
+    from .ingest_files import DataArray, IngestFiles
     from .expression_files.expression_files import GeneExpression
-    from .monitor import log_exception
+    from .monitor import log_exception, bypass_mongo_writes
     from .validation.validate_metadata import list_duplicates
 
 
-class AnnDataIngestor(GeneExpression, IngestFiles):
+class AnnDataIngestor(GeneExpression, IngestFiles, DataArray):
     ALLOWED_FILE_TYPES = ['application/x-hdf5']
 
     def __init__(self, file_path, study_file_id, study_id, **kwargs):
@@ -56,6 +56,33 @@ class AnnDataIngestor(GeneExpression, IngestFiles):
             return True
         except ValueError:
             return False
+
+    def create_cell_data_arrays(self):
+        """Extract cell name DataArray documents for raw data"""
+        adata = self.obtain_adata()
+        cells = list(adata.obs_names)
+        # use filename denoting a raw 'fragment' to allow successful ingest and downstream queries
+        raw_filename = "h5ad_frag.matrix.raw.mtx.gz"
+        data_arrays = []
+        for data_array in GeneExpression.create_data_arrays(
+            name=f"{raw_filename} Cells",
+            array_type="cells",
+            values=cells,
+            linear_data_type="Study",
+            linear_data_id=self.study_file_id,
+            cluster_name=raw_filename,
+            study_file_id=self.study_file_id,
+            study_id=self.study_id
+        ):
+            data_arrays.append(data_array)
+
+        return data_arrays
+
+    def ingest_raw_cells(self):
+        """Insert raw count cells into MongoDB"""
+        arrays = self.create_cell_data_arrays()
+        if not bypass_mongo_writes():
+            self.load(arrays, DataArray.COLLECTION_NAME)
 
     @staticmethod
     def generate_cluster_header(adata, clustering_name):

--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -83,6 +83,9 @@ class AnnDataIngestor(GeneExpression, IngestFiles, DataArray):
         arrays = self.create_cell_data_arrays()
         if not bypass_mongo_writes():
             self.load(arrays, DataArray.COLLECTION_NAME)
+        else:
+            dev_msg = f"Extracted {len(arrays)} DataArray for {self.study_file_id}:{arrays[0]['name']}"
+            IngestFiles.dev_logger.info(dev_msg)
 
     @staticmethod
     def generate_cluster_header(adata, clustering_name):

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -101,6 +101,13 @@ class GeneExpression:
         QUERY = {"_id": study_file_id, "study_id": study_id}
 
         study_file_doc = list(client[COLLECTION_NAME].find(QUERY)).pop()
+        # special handling of non-reference AnnData files to always return false
+        # this will allow normal extraction of expression data as raw count cells are already ingested during
+        # the "raw_counts" extract phase
+        if (study_file_doc["file_type"] == "AnnData" and "ann_data_file_info" in study_file_doc.keys() and not
+          study_file_doc["ann_data_file_info"]["reference_file"]):
+            return False
+
         # Name of embedded document that holds 'is_raw_count_files is named expression_file_info.
         # If study files does not have document expression_file_info
         # field, "is_raw_count_files", will not exist.:

--- a/ingest/expression_files/expression_files.py
+++ b/ingest/expression_files/expression_files.py
@@ -104,8 +104,8 @@ class GeneExpression:
         # special handling of non-reference AnnData files to always return false
         # this will allow normal extraction of expression data as raw count cells are already ingested during
         # the "raw_counts" extract phase
-        if (study_file_doc["file_type"] == "AnnData" and "ann_data_file_info" in study_file_doc.keys() and not
-          study_file_doc["ann_data_file_info"]["reference_file"]):
+        if (study_file_doc.get("file_type") == "AnnData" and "ann_data_file_info" in study_file_doc.keys() and not
+          study_file_doc["ann_data_file_info"].get("reference_file")):
             return False
 
         # Name of embedded document that holds 'is_raw_count_files is named expression_file_info.

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -54,6 +54,9 @@ python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5
 # Ingest AnnData - happy path processed expression data only extraction
 python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --ingest-anndata --anndata-file ../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad  --extract "['processed_expression']"
 
+# Ingest AnnData - happy path raw count cell name only extraction
+python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --ingest-anndata --anndata-file ../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad  --extract "['raw_counts']"
+
 # Ingest AnnData - happy path cluster and metadata extraction
 python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --ingest-anndata --anndata-file ../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad  --extract "['cluster', 'metadata']" --obsm-keys "['X_umap','X_tsne']"
 
@@ -537,6 +540,11 @@ class IngestPipeline:
                 "extract"
             ):
                 self.anndata.generate_processed_matrix(self.anndata.adata)
+
+            if self.kwargs.get('extract') and "raw_counts" in self.kwargs.get(
+                "extract"
+            ):
+                self.anndata.ingest_raw_cells()
             self.report_validation("success")
             return 0
         # scanpy unable to open AnnData file

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -228,3 +228,9 @@ class TestAnnDataIngestor(unittest.TestCase):
                 "expected 1 call to delocalize output files",
             )
 
+    def test_extract_raw_cells(self):
+        arrays = self.anndata_ingest.create_cell_data_arrays()
+        self.assertEqual(len(arrays), 1)
+        data_array = arrays[0]
+        self.assertEqual('h5ad_frag.matrix.raw.mtx.gz Cells', data_array['name'])
+        self.assertEqual(2638, len(data_array['values']))

--- a/tests/test_expression_files.py
+++ b/tests/test_expression_files.py
@@ -269,6 +269,15 @@ class TestExpressionFiles(unittest.TestCase):
             )
         )
 
+        client["study_files"].find.return_value = [
+            {"file_type": "AnnData", "ann_data_file_info": {"reference_file": False}}
+        ]
+        self.assertFalse(
+            GeneExpression.is_raw_count_file(
+                TestExpressionFiles.STUDY_ID, TestExpressionFiles.STUDY_FILE_ID, client
+            )
+        )
+
     def test_get_study_expression_file_ids(self):
         RAW_COUNTS_QUERY = {
             "$and": [{"study_id": ObjectId("5d276a50421aa9117c982845")}],


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds a new `raw_counts` extraction phase for AnnData files where a list of cell names is inserted into MongoDB as the "raw" cells for this file.  Usually we extract flat files and then use existing ingest classes to process the data.  However, since we only require the cell names for raw counts data, and extracting a full MTX bundle would as such be pointless, this update reads the cell names directly from the AnnData file.  This assumes that there is data in the `adata.raw` slot, and that the cells represented there match those in `adata.obs_names`.  There may be future work required if users are not using that slot, and we may wish to let them specify which slot the raw data is in, or even which index the cell names are.  But for now, the slots are hard-coded.  This is part of work to enable downstream portal actions, such as automated differential expression calculation for AnnData files.

#### MANUAL TESTING
1. Initialize your dev environment as normal
2. Run the example command for AnnData raw counts extraction:
```
python ingest_pipeline.py  --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --ingest-anndata --anndata-file ../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad  --extract "['raw_counts']"
```
3. Ensure no error was thrown: 
```
% echo $?
0
```
4. In `log.txt`, look for the following message:
```
2024-08-21T11:42:14-0400 ingest_files INFO:Extracted 1 DataArray for 5dd5ae25421aa910a723a337:h5ad_frag.matrix.raw.mtx.gz Cells
```