### PR TITLE
Ensure numeric metadata in adata.obs are assigned TYPE numeric in metadata fragment files

### DIFF
--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -117,7 +117,7 @@ class AnnDataIngestor(GeneExpression, IngestFiles):
         headers = adata.obs.columns.tolist()
         types = []
         for header in headers:
-            if pd.api.types.is_number(adata.obs[header]):
+            if pd.api.types.is_numeric_dtype(adata.obs[header]):
                 types.append("NUMERIC")
             else:
                 types.append("GROUP")

--- a/scripts/sSCP395_h5ad_CAS.qmd
+++ b/scripts/sSCP395_h5ad_CAS.qmd
@@ -1,0 +1,169 @@
+---
+title: "sSCP395 h5ad for CAS"
+format: html
+---
+
+
+```{python}
+import numpy as np
+import pandas as pd
+import scanpy as sc
+adata = sc.read_10x_h5("PBMChealthyNoSort3k2.0.0/pbmc_unsorted_3k_filtered_feature_bc_matrix.h5")
+adata
+```
+
+ ```{python}
+ meta = pd.read_csv('prep_files/orig_10xmultiome_metadata4h5ad.tsv', sep="\t", index_col=0)
+ adata.obs = meta
+ ```
+
+
+```{python}
+umap = pd.read_csv('PBMChealthyNoSort3k2.0.0/analysis/dimensionality_reduction/gex/umap_projection.csv', usecols=[1, 2]).to_numpy()
+tsne = pd.read_csv('PBMChealthyNoSort3k2.0.0/analysis/dimensionality_reduction/gex/tsne_projection.csv', usecols=[1, 2]).to_numpy()
+```
+
+
+```{python}
+adata.obsm["X_umap"] = umap
+adata.obsm["X_tsne"] = tsne
+```
+
+
+```{python}
+adata.write_h5ad("sSCP395.h5ad")
+```
+
+# start CAS notebook
+
+
+```{python}
+import scanpy as sc
+import warnings
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+sc.set_figure_params(dpi=80)
+```
+
+
+
+```{python}
+sc.pl.umap(adata, color='gex_cluster')
+```
+
+
+```{python}
+with open(".cas-api-token") as f:
+    api_token = f.read().strip()"
+```
+
+
+```{python}
+from cellarium.cas.client import CASClient
+
+cas = CASClient(api_token=api_token)
+```
+
+
+```{python}
+cas_model_name = 'cellarium-pca-default-v1'
+cas_ontology_aware_response = cas.annotate_matrix_cell_type_ontology_aware_strategy(
+    matrix=adata,
+    chunk_size=500,
+    feature_ids_column_name='gene_ids',
+    feature_names_column_name='index',
+    cas_model_name=cas_model_name)
+```
+
+```{python}
+from cellarium.cas._io import suppress_stderr
+from cellarium.cas.visualization import CASCircularTreePlotUMAPDashApp
+
+DASH_SERVER_PORT = 8050
+
+with suppress_stderr():
+    CASCircularTreePlotUMAPDashApp(
+        adata,  # the AnnData file
+        cas_ontology_aware_response,  # CAS response
+        cluster_label_obs_column="gex_label",  # (optional) The .obs column name containing cluster labels
+    ).run(port=DASH_SERVER_PORT, debug=False, jupyter_width="100%")
+```
+
+```{python}
+import cellarium.cas.postprocessing.ontology_aware as pp
+from cellarium.cas.postprocessing.cell_ontology import CellOntologyCache
+
+with suppress_stderr():
+  cl = CellOntologyCache()
+```
+
+```{python}
+from cellarium.cas.postprocessing import insert_cas_ontology_aware_response_into_adata
+
+insert_cas_ontology_aware_response_into_adata(cas_ontology_aware_response, adata, cl)
+```
+```{python}
+
+adata.obs["gex_cluster"] = adata.obs["gex_cluster"].astype('category')
+pp.compute_most_granular_top_k_calls_cluster(
+        adata=adata,
+        cl=cl,
+        min_acceptable_score=0.1,  # minimum acceptable score for a call
+        cluster_label_obs_column='gex_cluster',  # .obs column containing cluster labels
+        top_k=3,  # how many top calls to make?
+        obs_prefix='cell_type_cas_cluster_calls'  # .obs column to write the top-k calls to
+    )
+```
+
+```{python}
+pp.compute_most_granular_top_k_calls_single(
+    adata=adata,
+    cl=cl,
+    min_acceptable_score=0.1,  # minimum acceptable score for a call
+    top_k=3,  # how many top calls to make?
+    obs_prefix="cas_cell_type_single_calls"  # .obs column to write the top-k calls to
+)
+```
+
+```{python}
+import pickle
+pickle.dump(cas_ontology_aware_response, open( "ontology_aware_strategy_cas_response.pickle", "wb"))
+```
+
+```{python}
+test = cas.annotate_matrix_cell_type_summary_statistics_strategy(adata)
+```
+
+
+```{python}
+import json
+with open("ontology_aware_strategy_cas_response.json", "w") as f:
+        f.write(json.dumps(cas_ontology_aware_response))
+
+with open("cell_type_summary_statistics_strategy_response.json", "w") as f:
+        f.write(json.dumps(test))
+```
+
+
+```{python}
+
+adata.write_h5ad("sSCP395_CAS-annotated.h5ad")
+```
+
+```{python}
+cluster_types = ["umap", "tsne"]
+mask = adata.obs.columns.str.contains('.*cell_type.*label.*')
+extracted = adata.obs.loc[:,mask]
+headers = ["NAME", "X", "Y" ] + extracted.columns.to_list()
+types = ["TYPE"] + ["group"] * (len(headers) - 1)
+for ctype in cluster_types:
+  cluster_slot = "X_" + ctype
+  cluster = pd.DataFrame(adata.obsm[cluster_slot])
+  cluster.index = adata.obs_names
+  cluster = pd.concat([cluster,extracted], axis=1)
+  filename = ctype + ".tsv"
+  with open(filename, "w") as file:
+      file.write('\t'.join(map(str,headers)) + "\n")
+      file.write('\t'.join(map(str,types)) + "\n")
+  cluster.to_csv(filename, mode='a', sep="\t", index=True, header=False)
+```

--- a/scripts/sSCP407_CAS_single.qmd
+++ b/scripts/sSCP407_CAS_single.qmd
@@ -1,0 +1,156 @@
+---
+title: "sSCP407 single CAS"
+format: html
+---
+
+```{python}
+!curl -O https://storage.googleapis.com/cellarium-file-system-public/cellarium-cas-tutorial/pbmc_10x_v3_4k.h5ad
+```
+
+```{python}
+import numpy as np
+import pandas as pd
+import scanpy as sc
+adata = sc.read_h5ad("pbmc_10x_v3_4k.h5ad")
+adata
+```
+
+# start CAS notebook
+
+
+```{python}
+import scanpy as sc
+import warnings
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+sc.set_figure_params(dpi=80)
+```
+
+
+```{python}
+with open(".cas-api-token") as f:
+    api_token = f.read().strip()"
+```
+
+
+```{python}
+from cellarium.cas.client import CASClient
+
+cas = CASClient(api_token=api_token)
+```
+
+
+```{python}
+cas_model_name = 'cellarium-pca-default-v1'
+cas_ontology_aware_response = cas.annotate_matrix_cell_type_ontology_aware_strategy(
+    matrix=adata,
+    chunk_size=500,
+    feature_ids_column_name='gene_ids',
+    feature_names_column_name='index',
+    cas_model_name=cas_model_name)
+```
+
+```{python}
+from cellarium.cas._io import suppress_stderr
+from cellarium.cas.visualization import CASCircularTreePlotUMAPDashApp
+```
+
+```{python}
+import cellarium.cas.postprocessing.ontology_aware as pp
+from cellarium.cas.postprocessing.cell_ontology import CellOntologyCache
+
+with suppress_stderr():
+  cl = CellOntologyCache()
+```
+
+```{python}
+from cellarium.cas.postprocessing import insert_cas_ontology_aware_response_into_adata
+
+insert_cas_ontology_aware_response_into_adata(cas_ontology_aware_response, adata, cl)
+```
+
+```{python}
+
+pp.compute_most_granular_top_k_calls_cluster(
+        adata=adata,
+        cl=cl,
+        min_acceptable_score=0.1,  # minimum acceptable score for a call
+        cluster_label_obs_column='cluster_label',  # .obs column containing cluster labels
+        top_k=3,  # how many top calls to make?
+        obs_prefix='cell_type_cas_cluster_calls'  # .obs column to write the top-k calls to
+    )
+```
+
+```{python}
+pp.compute_most_granular_top_k_calls_single(
+    adata=adata,
+    cl=cl,
+    min_acceptable_score=0.1,  # minimum acceptable score for a call
+    top_k=3,  # how many top calls to make?
+    obs_prefix="cas_cell_type_single_calls"  # .obs column to write the top-k calls to
+)
+```
+
+
+```{python}
+test = cas.annotate_matrix_cell_type_summary_statistics_strategy(adata)
+```
+
+# write out both CAS result files as json
+```{python}
+import json
+with open("ontology_aware_strategy_cas_response.json", "w") as f:
+        f.write(json.dumps(cas_ontology_aware_response))
+
+with open("cell_type_summary_statistics_strategy_response.json", "w") as f:
+        f.write(json.dumps(test))
+```
+
+# add dummy metadata for SCP convention
+# Note: lpp is possibly incorrect
+```{python}
+adata.obs['biosample_id'] = "sample-1"
+adata.obs['donor_id'] = "donor-1"
+adata.obs['species'] = "NCBITaxon_9606"
+adata.obs['species__ontology_label'] = "Homo sapiens"
+adata.obs['disease'] = "PATO_0000461"
+adata.obs['disease__ontology_label'] = "normal"
+adata.obs['organ'] = "UBERON_0000178"
+adata.obs['organ__ontology_label'] = "blood"
+adata.obs['library_preparation_protocol'] = "EFO_0030059"
+adata.obs['library_preparation_protocol__ontology_label'] = "10x multiome"
+adata.obs['sex'] = "female"
+```
+# update numeric metadata to be of appropriate numeric type in dataframe
+
+```{python}
+scores = adata.obs.columns.str.contains('.*cell_type.*score.*')
+adata.obs.loc[:, scores] = adata.obs.loc[:, scores].astype(float)
+```
+# write AnnData to file
+
+```{python}
+
+adata.write_h5ad("sSCP407_CAS.h5ad")
+```
+
+# extract cell type label annotations to a clustering file
+
+```{python}
+cluster_types = ["umap"]
+mask = adata.obs.columns.str.contains('.*cell_type.*label.*')
+extracted = adata.obs.loc[:,mask]
+headers = ["NAME", "X", "Y" ] + extracted.columns.to_list()
+types = ["TYPE"] + ["group"] * (len(headers) - 1)
+for ctype in cluster_types:
+  cluster_slot = "X_" + ctype
+  cluster = pd.DataFrame(adata.obsm[cluster_slot])
+  cluster.index = adata.obs_names
+  cluster = pd.concat([cluster,extracted], axis=1)
+  filename = "sSCP407_"+ ctype + ".tsv"
+  with open(filename, "w") as file:
+      file.write('\t'.join(map(str,headers)) + "\n")
+      file.write('\t'.join(map(str,types)) + "\n")
+  cluster.to_csv(filename, mode='a', sep="\t", index=True, header=False)
+```
+

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -134,8 +134,8 @@ class TestAnnDataIngestor(unittest.TestCase):
         )
         compressed_file = self.metadata_filename + ".gz"
         with gzip.open(compressed_file, "rt", encoding="utf-8-sig") as metadata_body:
-            line = metadata_body.readline().split("\t")
-            expected_line = [
+            name_line = metadata_body.readline().split("\t")
+            expected_names = [
                 'NAME',
                 'n_genes',
                 'percent_mito',
@@ -154,7 +154,29 @@ class TestAnnDataIngestor(unittest.TestCase):
                 "library_preparation_protocol__ontology_label\n",
             ]
             self.assertEqual(
-                expected_line, line, 'did not get expected headers from metadata body'
+                expected_names, name_line, 'did not get expected headers from metadata body'
+            )
+            type_line = metadata_body.readline().split("\t")
+            expected_types = [
+                'TYPE',
+                'NUMERIC',
+                'NUMERIC',
+                'NUMERIC',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                'GROUP',
+                "GROUP\n",
+            ]
+            self.assertEqual(
+                expected_types, type_line, 'did not get expected types from metadata body'
             )
 
     def test_gene_id_indexed_generate_processed_matrix(self):


### PR DESCRIPTION
A typo in AnnData extraction caused numeric metadata to be assigned TYPE `group` on AnnData metadata fragment extraction. This PR fixes the error and adds an automated test to ensure that numeric TYPE assignment occurs correctly.

Additionally, two quarto files are included for reference on CAS processing:
-  `sSCP395_h5ad_CAS.qmd`, includes running individual cell type calls and generation of clustering files with resulting CAS labels (after generating an h5ad file from component sSCP395 "classic" SCP files)
- `sSCP407_CAS_single.qmd`, runs CAS individual and cluster cell type calling and then sets scores to a numeric dtype in the AnnData object.

This work ensures that the AnnData from `sSCP407_CAS_single.qmd` can be used to visualizate CAS scores as continuous data.

#### MANUAL TESTING
1. Initialize your dev environment as normal
2. Run the example command for AnnData metadata extraction:
```
python ingest_pipeline.py  --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 ingest_anndata --ingest-anndata --anndata-file ../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad  --extract '["metadata"]'
```
3. Confirm the TYPE for n_genes, percent_mito, and n_counts are NUMERIC
```
zcat < h5ad_frag.metadata.tsv.gz | head -2
```
[optional] 4. Confirm that the resulting metadata file passes file validation
```
python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 ingest_cell_metadata --cell-metadata-file h5ad_frag.metadata.tsv.gz --study-accession SCPtest20240821 --ingest-cell-metadata --validate-convention 
```
