### PR TITLE
Add secondary data check for Ensembl gene ID index (SCP-5853)

### DIFF
--- a/.github/workflows/minify_ontologies.yml
+++ b/.github/workflows/minify_ontologies.yml
@@ -3,9 +3,9 @@ name: Minify ontologies
 on:
   pull_request:
     types: [opened]  # Only trigger on PR "opened" event
-  push: # Uncomment, update branches to develop / debug
-    branches:
-      jb-metadata-boolean
+#  push: # Uncomment, update branches to develop / debug
+#    branches:
+#      jb-metadata-boolean
 
 jobs:
   build:

--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -187,7 +187,7 @@ class AnnDataIngestor(GeneExpression, IngestFiles, DataArray):
         h5ad_frag.features.processed.tsv
         Gzip files for faster delocalization
         """
-        if adata.var.index.name == 'gene_ids':
+        if AnnDataIngestor.check_ensembl_index(adata):
             # CELLxGENE indexes by Ensembl gene ID, not gene name (i.e. symbol).
             # Gene name is encoded in feature_name, which is needed for gene search.
             feature_frame = adata.var.feature_name
@@ -215,6 +215,15 @@ class AnnDataIngestor(GeneExpression, IngestFiles, DataArray):
             mtx_filename, a=scipy.sparse.csr_matrix(adata.X.T), precision=3
         )
         AnnDataIngestor.compress_file(mtx_filename)
+
+    @staticmethod
+    def check_ensembl_index(adata):
+        """Check if an AnnData file is indexed on Ensembl gene IDs (e.g. ENSG00000243485) instead of gene symbols"""
+        if adata.var.index.name == 'gene_ids':
+            return True
+        else:
+            prefixes = list(set(gene_id[:4] for gene_id in adata.var_names))
+            return len(prefixes) == 1 and prefixes[0] == 'ENSG'
 
     @staticmethod
     def delocalize_extracted_files(

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -266,6 +266,21 @@ class TestAnnDataIngestor(unittest.TestCase):
             first_line, expected_first_line, 'Expected Ensembl ID and gene name'
         )
 
+    def test_check_if_indexed_by_gene_id(self):
+        # check var.index.name
+        feature_name = AnnDataIngestor(
+            "../tests/data/anndata/indexed_by_gene_id.h5ad", self.study_id, self.study_file_id
+        )
+        adata = feature_name.obtain_adata()
+        self.assertTrue(feature_name.check_ensembl_index(adata))
+
+        # check data inspection
+        data_inspect = AnnDataIngestor(
+            "../tests/data/anndata/cellxgene.human_liver_b_cells.h5ad", self.study_id, self.study_file_id
+        )
+        liver_adata = data_inspect.obtain_adata()
+        self.assertTrue(data_inspect.check_ensembl_index(liver_adata))
+
 
     def test_get_files_to_delocalize(self):
         files = AnnDataIngestor.clusterings_to_delocalize(self.valid_kwargs)

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -281,6 +281,12 @@ class TestAnnDataIngestor(unittest.TestCase):
         liver_adata = data_inspect.obtain_adata()
         self.assertTrue(data_inspect.check_ensembl_index(liver_adata))
 
+        # negative test
+        gene_symbols = AnnDataIngestor(
+            "../tests/data/anndata/anndata_test.h5ad", self.study_id, self.study_file_id
+        )
+        normal_adata = gene_symbols.obtain_adata()
+        self.assertFalse(gene_symbols.check_ensembl_index(normal_adata))
 
     def test_get_files_to_delocalize(self):
         files = AnnDataIngestor.clusterings_to_delocalize(self.valid_kwargs)


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds a secondary data inspection check when determining if an AnnData file is indexed using Ensembl gene IDs (e.g. ENSG0000...) rather than traditional gene symbols.  Instead of relying on `adata.var.index.name` to declare `gene_ids`, now the `adata.var_names` list is dumped and the first 4 characters from every entry is added to a set.  If the matrix indexes on IDs, then the set should have only one entry of `ENSG`.

#### MANUAL TESTING
1. Initialize local environment as normal and enter a Python shell
2. Load the `AnnDataIngestor` module and initialize with a small CellXGene formatted file:
```
from anndata_ import AnnDataIngestor
ingestor = AnnDataIngestor('../tests/data/anndata/cellxgene.human_liver_b_cells.h5ad', 'addedfeed000000000000000', 'dec0dedfeed1111111111111')
adata = ingestor.obtain_adata()
```
3. Confirm that the file does not have a value declared for `var.index.name` but still returns that it is indexed on Ensembl IDs:
```
>>> print(adata.var.index.name)
None
>>> ingestor.check_ensembl_index(adata)
True
```
4. (Optional): Confirm the exported features file has both gene IDs and symbols:
```
import pandas as pd
feature_frame = adata.var.feature_name
index = True
pd.DataFrame(feature_frame).to_csv(
    "h5ad_frag.features.processed.tsv.gz",
    sep="\t",
    index=index,
    header=False,
    compression="gzip",
)

### exported file should look like this
ENSG00000000003	TSPAN6
ENSG00000000005	TNMD
ENSG00000000419	DPM1
ENSG00000000457	SCYL3
ENSG00000000460	C1orf112
ENSG00000000938	FGR
ENSG00000000971	CFH
...
```