### PR TITLE
Enable pairwise DE in ingest pipeline (SCP-5766)

### DIFF
--- a/.github/workflows/minify_ontologies.yml
+++ b/.github/workflows/minify_ontologies.yml
@@ -3,9 +3,9 @@ name: Minify ontologies
 on:
   pull_request:
     types: [opened]  # Only trigger on PR "opened" event
-#  push: # Uncomment, update branches to develop / debug
-#    branches:
-#      jlc_show_gene_name 
+ push: # Uncomment, update branches to develop / debug
+   branches:
+     jlc_show_de_pairwise
 
 jobs:
   build:

--- a/.github/workflows/minify_ontologies.yml
+++ b/.github/workflows/minify_ontologies.yml
@@ -3,9 +3,9 @@ name: Minify ontologies
 on:
   pull_request:
     types: [opened]  # Only trigger on PR "opened" event
- push: # Uncomment, update branches to develop / debug
-   branches:
-     jlc_show_de_pairwise
+# push: # Uncomment, update branches to develop / debug
+#   branches:
+#     jlc_show_de_pairwise
 
 jobs:
   build:

--- a/ingest/anndata_.py
+++ b/ingest/anndata_.py
@@ -6,6 +6,7 @@ import scanpy as sc
 import scipy
 from scipy.io.mmio import MMFile
 
+
 # scipy.io.mmwrite uses scientific notation by default
 # https://stackoverflow.com/questions/64748513
 class MMFileFixedFormat(MMFile):
@@ -72,7 +73,7 @@ class AnnDataIngestor(GeneExpression, IngestFiles, DataArray):
             linear_data_id=self.study_file_id,
             cluster_name=raw_filename,
             study_file_id=self.study_file_id,
-            study_id=self.study_id
+            study_id=self.study_id,
         ):
             data_arrays.append(data_array)
 

--- a/ingest/cell_metadata.py
+++ b/ingest/cell_metadata.py
@@ -7,6 +7,7 @@ Text, CSV, and TSV files are supported.
 PREREQUISITES
 Must have python 3.6 or higher.
 """
+
 import collections
 import ntpath
 from collections import defaultdict, OrderedDict
@@ -115,6 +116,7 @@ class CellMetadata(Annotations):
                 "error", msg, "format:cap:metadata-no-coordinates"
             )
             return False
+
     @staticmethod
     def make_multiindex_name(modality):
         """From modality, generate column name in multi-index format"""
@@ -127,7 +129,9 @@ class CellMetadata(Annotations):
         """Translate presence of single modality to boolean for BigQuery"""
         # check for empty cells (aka. nan) or empty strings
         modality_multiindex = CellMetadata.make_multiindex_name(modality)
-        no_modality_info = df[modality_multiindex].isna() | df[modality_multiindex].str.len().eq(0)
+        no_modality_info = df[modality_multiindex].isna() | df[
+            modality_multiindex
+        ].str.len().eq(0)
         bool_name = modality + "_bool"
         bool_multiindex = CellMetadata.make_multiindex_name(bool_name)
         # store inverse of no_modality_info (ie. True = has modality info)
@@ -145,12 +149,12 @@ class CellMetadata(Annotations):
             m_to_rename[bool_name] = has_m
         self.modality_urls = self.file.filter(m_to_hide, axis=1)
         self.file.drop(m_to_hide, axis=1, inplace=True)
-        self.file.rename(columns= m_to_rename, inplace=True)
+        self.file.rename(columns=m_to_rename, inplace=True)
         return
 
     def booleanize_modality_metadata(self):
         """Translate presence of modality data to boolean for BigQuery
-           If no modality data, self.files is unchanged
+        If no modality data, self.files is unchanged
         """
         if self.modalities is not None:
             df = copy.deepcopy(self.file)

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -344,7 +344,13 @@ def create_parser():
 
     # For pairwise analyses
     parser_differential_expression.add_argument(
-        "--reference",
+        "--group1",
+        type=ast.literal_eval,
+        help="1st annotation group to use for pairwise DE analysis",
+    )
+
+    parser_differential_expression.add_argument(
+        "--group2",
         help="2nd annotation group to use for pairwise DE analysis",
     )
 

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -346,13 +346,10 @@ def create_parser():
     # For pairwise analyses
     parser_differential_expression.add_argument(
         "--group1",
-        # rank_genes_groups accepts a list for the `groups` parameter
-        type=ast.literal_eval,
         help="1st annotation group to use for pairwise DE analysis",
     )
 
     parser_differential_expression.add_argument(
-        # rank_genes_groups expects a string for the `reference` parameter
         "--group2",
         help="2nd annotation group to use for pairwise DE analysis",
     )

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -277,7 +277,7 @@ def create_parser():
     parser_differential_expression.add_argument(
         "--de-type",
         default="rest",
-        choices=['rest', 'pairwise']
+        choices=['rest', 'pairwise'],
         help="Accepted values: 'pairwise' or 'rest' (default)",
     )
 
@@ -346,11 +346,13 @@ def create_parser():
     # For pairwise analyses
     parser_differential_expression.add_argument(
         "--group1",
+        # rank_genes_groups accepts a list for the `groups` parameter
         type=ast.literal_eval,
         help="1st annotation group to use for pairwise DE analysis",
     )
 
     parser_differential_expression.add_argument(
+        # rank_genes_groups expects a string for the `reference` parameter
         "--group2",
         help="2nd annotation group to use for pairwise DE analysis",
     )

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -277,7 +277,8 @@ def create_parser():
     parser_differential_expression.add_argument(
         "--de-type",
         default="rest",
-        help="Accepted values: 'pairwise' or 'rest'",
+        choices=['rest', 'pairwise']
+        help="Accepted values: 'pairwise' or 'rest' (default)",
     )
 
     parser_differential_expression.add_argument(

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -275,6 +275,12 @@ def create_parser():
     )
 
     parser_differential_expression.add_argument(
+        "--de-type",
+        default="rest",
+        help="Accepted values: 'pairwise' or 'rest'",
+    )
+
+    parser_differential_expression.add_argument(
         "--study-accession",
         required=True,
         help="Single study accession associated with provided DE input files.",
@@ -334,6 +340,12 @@ def create_parser():
     )
     parser_differential_expression.add_argument(
         "--gene-file", help="Path to .genes.tsv file"
+    )
+
+    # For pairwise analyses
+    parser_differential_expression.add_argument(
+        "--reference",
+        help="2nd annotation group to use for pairwise DE analysis",
     )
 
     parser_ingest_differential_expression = subparsers.add_parser(

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -395,40 +395,38 @@ def create_parser():
     parser_ingest_differential_expression.add_argument(
         "--differential-expression-file",
         required=True,
-        help="Path to DE file uploaded by author."
+        help="Path to DE file uploaded by author.",
     )
 
     parser_ingest_differential_expression.add_argument(
         "--gene-header",
         required=True,
-        help="Header used for gene names / symbols in DE file"
+        help="Header used for gene names / symbols in DE file",
     )
 
     parser_ingest_differential_expression.add_argument(
-        "--group-header",
-        required=True,
-        help="Header used for group in DE file"
+        "--group-header", required=True, help="Header used for group in DE file"
     )
 
     parser_ingest_differential_expression.add_argument(
         "--comparison-group-header",
         required=False,
         help=(
-            "Header used for comparison group in DE file.  " +
-            "For pairwise comparisons.  Can omit if DE file is in one-vs-rest-only format."
-        )
+            "Header used for comparison group in DE file.  "
+            + "For pairwise comparisons.  Can omit if DE file is in one-vs-rest-only format."
+        ),
     )
 
     parser_ingest_differential_expression.add_argument(
         "--size-metric",
         required=True,
-        help='Header used as size metric in DE file, e.g. "logfoldchanges", "avg_log2FC", etc.'
+        help='Header used as size metric in DE file, e.g. "logfoldchanges", "avg_log2FC", etc.',
     )
 
     parser_ingest_differential_expression.add_argument(
         "--significance-metric",
         required=True,
-        help='Header used as significance metric in DE file, e.g. "pvals_adj", "p_val_adj", etc.'
+        help='Header used as significance metric in DE file, e.g. "pvals_adj", "p_val_adj", etc.',
     )
 
     # AnnData subparsers
@@ -511,7 +509,7 @@ def create_parser():
     parser_rank_genes.add_argument(
         '--publication',
         help="URL of the study's publicly-accessible research article, or GS URL or local path to publication text file",
-        required=True
+        required=True,
     )
 
     return parser

--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -346,12 +346,12 @@ def create_parser():
     # For pairwise analyses
     parser_differential_expression.add_argument(
         "--group1",
-        help="1st annotation group to use for pairwise DE analysis",
+        help="1st annotation label to use for pairwise DE analysis",
     )
 
     parser_differential_expression.add_argument(
         "--group2",
-        help="2nd annotation group to use for pairwise DE analysis",
+        help="2nd annotation label to use for pairwise DE analysis",
     )
 
     parser_ingest_differential_expression = subparsers.add_parser(

--- a/ingest/clusters.py
+++ b/ingest/clusters.py
@@ -136,9 +136,11 @@ class Clusters(Annotations):
                 {
                     "name": annot_name,
                     "type": annot_type,
-                    "values": self.file[annot_headers].unique().tolist()
-                    if annot_type == "group"
-                    else [],
+                    "values": (
+                        self.file[annot_headers].unique().tolist()
+                        if annot_type == "group"
+                        else []
+                    ),
                 }
             )
         Annotations.dev_logger.info(f"Creating model for {self.study_id}")
@@ -148,9 +150,11 @@ class Clusters(Annotations):
             cell_annotations=cell_annotations,
             study_file_id=self.study_file_id,
             study_id=self.study_id,
-            domain_ranges=DomainRanges(**self.domain_ranges)
-            if self.domain_ranges is not None
-            else None,
+            domain_ranges=(
+                DomainRanges(**self.domain_ranges)
+                if self.domain_ranges is not None
+                else None
+            ),
         )
 
     def get_data_array_annot(self, linear_data_id):

--- a/ingest/de.py
+++ b/ingest/de.py
@@ -87,20 +87,24 @@ class DifferentialExpression:
                 if group1 and group2:
                     if group1 not in values or group2 not in values:
                         msg = (
-                        f'Provided annotation value(s) group1, \"{group1}\", '
-                        f'or group2, \"{group2}\", not found in metadata file'
+                            f'Provided annotation value(s) group1, \"{group1}\", '
+                            f'or group2, \"{group2}\", not found in metadata file'
                         )
                         log_exception(
-                            DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
+                            DifferentialExpression.dev_logger,
+                            DifferentialExpression.de_logger,
+                            msg,
                         )
                         raise ValueError(msg)
                 else:
                     msg = (
-                    f'Provided annotation value(s) group1, \"{group1}\", or '
-                    f'group2, \"{group2}\", were falsey'
+                        f'Provided annotation value(s) group1, \"{group1}\", or '
+                        f'group2, \"{group2}\", were false-y'
                     )
                     log_exception(
-                        DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
+                        DifferentialExpression.dev_logger,
+                        DifferentialExpression.de_logger,
+                        msg,
                     )
                     raise KeyError(msg)
             # de_type is "rest" by default, DE annotation TYPE expected to be group
@@ -114,8 +118,6 @@ class DifferentialExpression:
                 DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
             )
             raise ValueError(msg)
-
-
 
     @staticmethod
     def get_cluster_cells(cluster_cells):
@@ -205,15 +207,19 @@ class DifferentialExpression:
         return adata
 
     def execute_de(self):
-        DifferentialExpression.de_logger.info(f'dev_info: Starting DE for {self.accession}')
+        DifferentialExpression.de_logger.info(
+            f'dev_info: Starting DE for {self.accession}'
+        )
         try:
-        # only used in output filename, replacing non-alphanumeric with underscores
-        # except '+' replaced with 'pos'
+            # only used in output filename, replacing non-alphanumeric with underscores
+            # except '+' replaced with 'pos'
             self.cluster_name = DifferentialExpression.sanitize_string(
                 self.kwargs["name"]
             )
             if self.matrix_file_type in ["dense", "mtx", "h5ad"]:
-                DifferentialExpression.de_logger.info(f"preparing DE on {self.matrix_file_type} matrix")
+                DifferentialExpression.de_logger.info(
+                    f"preparing DE on {self.matrix_file_type} matrix"
+                )
                 self.run_scanpy_de(
                     self.cluster,
                     self.metadata,
@@ -235,7 +241,6 @@ class DifferentialExpression:
         except (TypeError, KeyError, ValueError) as e:
             raise ValueError(e)
         return
-
 
     @staticmethod
     def get_genes(genes_path):
@@ -333,16 +338,26 @@ class DifferentialExpression:
 
     @staticmethod
     def write_de_result(adata, group, annotation, rank_key, cluster_name, extra_params):
-        de_type =  extra_params.get("de_type")
+        de_type = extra_params.get("de_type")
         method = extra_params.get("method")
         annot_scope = extra_params.get("annotation_scope")
         clean_annotation = DifferentialExpression.sanitize_string(annotation)
         rank = sc.get.rank_genes_groups_df(adata, key=rank_key, group=group)
         if DifferentialExpression.all_match_ensembl_id_regex(rank, "names"):
-            feature_name_rank = rank.merge(adata.var['feature_name'], left_on="names", right_index=True, how='left')
+            feature_name_rank = rank.merge(
+                adata.var['feature_name'], left_on="names", right_index=True, how='left'
+            )
             feature_name_rank.rename(columns={'names': 'feature_id'}, inplace=True)
             feature_name_rank.rename(columns={'feature_name': 'names'}, inplace=True)
-            new_column_order = ["names"] + [col for col in feature_name_rank.columns if col not in {"names", "feature_id"}] + ["feature_id"]
+            new_column_order = (
+                ["names"]
+                + [
+                    col
+                    for col in feature_name_rank.columns
+                    if col not in {"names", "feature_id"}
+                ]
+                + ["feature_id"]
+            )
             feature_name_rank = feature_name_rank[new_column_order]
 
             rank = feature_name_rank
@@ -351,14 +366,20 @@ class DifferentialExpression:
         if de_type == "rest":
             clean_group = DifferentialExpression.sanitize_string(group)
             out_file = f'{cluster_name}--{clean_annotation}--{clean_group}--{annot_scope}--{method}.tsv'
-            DifferentialExpression.de_logger.info(f"Writing DE output for {clean_group} vs rest")
+            DifferentialExpression.de_logger.info(
+                f"Writing DE output for {clean_group} vs restq"
+            )
         elif de_type == "pairwise":
             # rank_genes_groups accepts a list. For SCP pairwise, should be a list with one item
             # converting list to string for incorporation into result filename
-            group1 = DifferentialExpression.sanitize_string(extra_params["group1"])
+            group1 = DifferentialExpression.sanitize_string(
+                ''.join(extra_params["group1"])
+            )
             group2 = DifferentialExpression.sanitize_string(extra_params["group2"])
             out_file = f'{cluster_name}--{clean_annotation}--{group1}--{group2}--{annot_scope}--{method}.tsv'
-            DifferentialExpression.de_logger.info(f"Writing DE output for {group1} vs {group2} pairwise")
+            DifferentialExpression.de_logger.info(
+                f"Writing DE output for {group1} vs {group2} pairwise"
+            )
         else:
             msg = f'Unknown de_type, {de_type}'
             print(msg)
@@ -369,7 +390,6 @@ class DifferentialExpression:
         # Round numbers to 4 significant digits while respecting fixed point
         # and scientific notation (note: trailing zeros are removed)
         rank.to_csv(out_file, sep='\t', float_format='%.4g')
-
 
     @staticmethod
     def run_scanpy_de(
@@ -417,15 +437,17 @@ class DifferentialExpression:
                     # using .copy() for the AnnData components is good practice
                     # but we won't be using orig_adata for analyses
                     # choosing to avoid .copy() for memory efficiency
-                    X = orig_adata.raw.X,
-                    obs = orig_adata.obs,
-                    var = orig_adata.var,
+                    X=orig_adata.raw.X,
+                    obs=orig_adata.obs,
+                    var=orig_adata.var,
                 )
             else:
                 msg = f'{matrix_file_path} does not have a .raw attribute'
                 print(msg)
                 log_exception(
-                    DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
+                    DifferentialExpression.dev_logger,
+                    DifferentialExpression.de_logger,
+                    msg,
                 )
                 raise ValueError(msg)
         # AnnData expects gene x cell so dense and mtx matrices require transposition
@@ -433,7 +455,6 @@ class DifferentialExpression:
             adata = adata.transpose()
 
         adata = DifferentialExpression.subset_adata(adata, de_cells)
-
 
         # h5ad inputs will already have obs data, only non-h5ad need this step
         if not matrix_file_type == "h5ad":
@@ -458,21 +479,27 @@ class DifferentialExpression:
                 msg = f"Missing expected annotation in metadata: {annotation}, unable to calculate DE."
                 print(msg)
                 log_exception(
-                    DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
+                    DifferentialExpression.dev_logger,
+                    DifferentialExpression.de_logger,
+                    msg,
                 )
                 raise KeyError(msg)
             # ToDo - detection and handling of annotations with only one sample (SCP-4282)
             except ValueError as e:
                 print(e)
                 log_exception(
-                    DifferentialExpression.dev_logger, DifferentialExpression.de_logger, e
+                    DifferentialExpression.dev_logger,
+                    DifferentialExpression.de_logger,
+                    e,
                 )
                 raise KeyError(e)
 
             DifferentialExpression.de_logger.info("Gathering DE annotation labels")
             groups = np.unique(adata.obs[annotation]).tolist()
             for group in groups:
-                DifferentialExpression.write_de_result(adata, group, annotation, rank_key, cluster_name, extra_params)
+                DifferentialExpression.write_de_result(
+                    adata, group, annotation, rank_key, cluster_name, extra_params
+                )
 
         elif de_type == 'pairwise':
             group1 = [extra_params["group1"]]
@@ -491,18 +518,29 @@ class DifferentialExpression:
                 msg = f"Missing expected annotation in metadata: {annotation}, unable to calculate DE."
                 print(msg)
                 log_exception(
-                    DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
+                    DifferentialExpression.dev_logger,
+                    DifferentialExpression.de_logger,
+                    msg,
                 )
                 raise KeyError(msg)
             # ToDo - detection and handling of annotations with only one sample (SCP-4282)
             except ValueError as e:
                 print(e)
                 log_exception(
-                    DifferentialExpression.dev_logger, DifferentialExpression.de_logger, e
+                    DifferentialExpression.dev_logger,
+                    DifferentialExpression.de_logger,
+                    e,
                 )
                 raise KeyError(e)
-            group1 = extra_params["group1"]
-            DifferentialExpression.write_de_result(adata, group1, annotation, rank_key, cluster_name, extra_params)
+            stringified_group1 = ''.join(extra_params["group1"])
+            DifferentialExpression.write_de_result(
+                adata,
+                stringified_group1,
+                annotation,
+                rank_key,
+                cluster_name,
+                extra_params,
+            )
 
         DifferentialExpression.de_logger.info("DE processing complete")
 

--- a/ingest/de.py
+++ b/ingest/de.py
@@ -78,10 +78,10 @@ class DifferentialExpression:
             )
             raise KeyError(msg)
         elif annotation_info == "group":
-            de_type =  extra_params.get("de_type")
+            de_type = extra_params.get("de_type")
             group1 = extra_params.get("group1")
             group2 = extra_params.get("group2")
-            if  de_type == "pairwise":
+            if de_type == "pairwise":
                 metadata.preprocess(False)
                 values = metadata.file[annotation]['group'].unique()
                 if group1 and group2:
@@ -97,7 +97,7 @@ class DifferentialExpression:
                 else:
                     msg = (
                     f'Provided annotation value(s) group1, \"{group1}\", or '
-                    f'group2, \"{group2}\", were false-y'
+                    f'group2, \"{group2}\", were falsey'
                     )
                     log_exception(
                         DifferentialExpression.dev_logger, DifferentialExpression.de_logger, msg
@@ -340,8 +340,8 @@ class DifferentialExpression:
         rank = sc.get.rank_genes_groups_df(adata, key=rank_key, group=group)
         if DifferentialExpression.all_match_ensembl_id_regex(rank, "names"):
             feature_name_rank = rank.merge(adata.var['feature_name'], left_on="names", right_index=True, how='left')
-            feature_name_rank.rename(columns={'names':'feature_id'}, inplace=True)
-            feature_name_rank.rename(columns={'feature_name':'names'}, inplace=True)
+            feature_name_rank.rename(columns={'names': 'feature_id'}, inplace=True)
+            feature_name_rank.rename(columns={'feature_name': 'names'}, inplace=True)
             new_column_order = ["names"] + [col for col in feature_name_rank.columns if col not in {"names", "feature_id"}] + ["feature_id"]
             feature_name_rank = feature_name_rank[new_column_order]
 
@@ -351,11 +351,11 @@ class DifferentialExpression:
         if de_type == "rest":
             clean_group = DifferentialExpression.sanitize_string(group)
             out_file = f'{cluster_name}--{clean_annotation}--{clean_group}--{annot_scope}--{method}.tsv'
-            DifferentialExpression.de_logger.info(f"Writing DE output for {clean_group} vs restq")
+            DifferentialExpression.de_logger.info(f"Writing DE output for {clean_group} vs rest")
         elif de_type == "pairwise":
             # rank_genes_groups accepts a list. For SCP pairwise, should be a list with one item
             # converting list to string for incorporation into result filename
-            group1 = DifferentialExpression.sanitize_string(''.join(extra_params["group1"]))
+            group1 = DifferentialExpression.sanitize_string(extra_params["group1"])
             group2 = DifferentialExpression.sanitize_string(extra_params["group2"])
             out_file = f'{cluster_name}--{clean_annotation}--{group1}--{group2}--{annot_scope}--{method}.tsv'
             DifferentialExpression.de_logger.info(f"Writing DE output for {group1} vs {group2} pairwise")
@@ -475,7 +475,7 @@ class DifferentialExpression:
                 DifferentialExpression.write_de_result(adata, group, annotation, rank_key, cluster_name, extra_params)
 
         elif de_type == 'pairwise':
-            group1 = extra_params["group1"]
+            group1 = [extra_params["group1"]]
             group2 = extra_params["group2"]
             try:
                 sc.tl.rank_genes_groups(
@@ -501,8 +501,8 @@ class DifferentialExpression:
                     DifferentialExpression.dev_logger, DifferentialExpression.de_logger, e
                 )
                 raise KeyError(e)
-            stringified_group1 = ''.join(extra_params["group1"])
-            DifferentialExpression.write_de_result(adata, stringified_group1, annotation, rank_key, cluster_name, extra_params)
+            group1 = extra_params["group1"]
+            DifferentialExpression.write_de_result(adata, group1, annotation, rank_key, cluster_name, extra_params)
 
         DifferentialExpression.de_logger.info("DE processing complete")
 

--- a/ingest/de.py
+++ b/ingest/de.py
@@ -176,7 +176,8 @@ class DifferentialExpression:
         return adata
 
     def execute_de(self):
-        print(f'dev_info: Starting DE for {self.accession}')
+        DifferentialExpression.de_logger.info(f'dev_info: Starting DE for {self.accession}')
+        #FIXME
         # try:
         # only used in output filename, replacing non-alphanumeric with underscores
         # except '+' replaced with 'pos'
@@ -184,15 +185,15 @@ class DifferentialExpression:
             self.kwargs["name"]
         )
         if self.matrix_file_type in ["dense", "mtx", "h5ad"]:
-                DifferentialExpression.de_logger.info(f"preparing DE on {self.matrix_file_type} matrix")
-                self.run_scanpy_de(
-                    self.cluster,
-                    self.metadata,
-                    self.matrix_file_path,
-                    self.matrix_file_type,
-                    self.annotation,
-                    self.cluster_name,
-                    self.kwargs,
+            DifferentialExpression.de_logger.info(f"preparing DE on {self.matrix_file_type} matrix")
+            self.run_scanpy_de(
+                self.cluster,
+                self.metadata,
+                self.matrix_file_path,
+                self.matrix_file_type,
+                self.annotation,
+                self.cluster_name,
+                self.kwargs,
             )
         else:
             msg = f"Submitted matrix_file_type should be \"dense\", \"mtx\" or \"h5ad\" not \"{self.matrix_file_type}\""
@@ -205,7 +206,7 @@ class DifferentialExpression:
             raise ValueError(msg)
         # except Exception as e:
         #     print(str(e))
-
+        return
 
 
     @staticmethod
@@ -309,7 +310,7 @@ class DifferentialExpression:
         # annot_scope = extra_params.get("annot_scope")
         de_type =  extra_params["de_type"]
         method = extra_params["method"]
-        annot_scope = extra_params["annot_scope"]
+        annot_scope = extra_params["annotation_scope"]
         clean_group = DifferentialExpression.sanitize_string(group)
         clean_annotation = DifferentialExpression.sanitize_string(annotation)
         rank = sc.get.rank_genes_groups_df(adata, key=rank_key, group=group)

--- a/ingest/ingest_files.py
+++ b/ingest/ingest_files.py
@@ -3,6 +3,7 @@
 DESCRIPTION
 Module provides extract capabilities for text, CSV, and TSV file types
 """
+
 import copy
 import csv
 import gzip
@@ -91,10 +92,10 @@ class IngestFiles:
     }
 
     def __init__(
-            self,
-            file_path: str,
-            allowed_file_types: list = list(ALLOWED_FILE_EXTENSIONS.keys())
-        ):
+        self,
+        file_path: str,
+        allowed_file_types: list = list(ALLOWED_FILE_EXTENSIONS.keys()),
+    ):
         """
         :param file_path: GS URL or local file path
         :param allowed_file_types (optional): list of allowed file MIME types

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -809,8 +809,6 @@ def main() -> None:
     parsed_args = create_parser().parse_args()
     validate_arguments(parsed_args)
     arguments = vars(parsed_args)
-    #FIXME hard code only for first pass refactor
-    arguments["de_type"] = "rest"
     if "differential_expression" in arguments:
         # DE may use metadata or cluster file for annots BUT
         # IngestPipeline initialization assumes a "cell_metadata_file"

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -809,6 +809,8 @@ def main() -> None:
     parsed_args = create_parser().parse_args()
     validate_arguments(parsed_args)
     arguments = vars(parsed_args)
+    #FIXME hard code only for first pass refactor
+    arguments["de_type"] = "rest"
     if "differential_expression" in arguments:
         # DE may use metadata or cluster file for annots BUT
         # IngestPipeline initialization assumes a "cell_metadata_file"

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -69,6 +69,15 @@ python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id de
 # Differential expression analysis (h5ad matrix)
 python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 differential_expression --annotation-name louvain --annotation-type group --annotation-scope study --matrix-file-path ../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad --matrix-file-type h5ad --annotation-file ../tests/data/anndata/h5ad_frag.metadata.tsv --cluster-file ../tests/data/anndata/h5ad_frag.cluster.X_umap.tsv --cluster-name umap --study-accession SCPdev --differential-expression
 
+# Pairwise differential expression analysis (dense matrix)
+python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 differential_expression --annotation-name cell_type__ontology_label --de-type pairwise --group1 "['cholinergic neuron']" --group2 "cranial somatomotor neuron" --annotation-type group --annotation-scope study --matrix-file-path ../tests/data/differential_expression/de_dense_matrix.tsv --matrix-file-type dense --annotation-file ../tests/data/differential_expression/de_dense_metadata.tsv --cluster-file ../tests/data/differential_expression/de_dense_cluster.tsv --cluster-name de_integration --study-accession SCPdev --differential-expression
+
+# Pairwise differential expression analysis (sparse matrix)
+python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 differential_expression --annotation-name cell_type__ontology_label --de-type pairwise --group1 "['endothelial cell']" --group2 "smooth muscle cell" --annotation-type group --annotation-scope study --matrix-file-path ../tests/data/differential_expression/sparse/sparsemini_matrix.mtx --gene-file ../tests/data/differential_expression/sparse/sparsemini_features.tsv --barcode-file ../tests/data/differential_expression/sparse/sparsemini_barcodes.tsv --matrix-file-type mtx --annotation-file ../tests/data/differential_expression/sparse/sparsemini_metadata.txt --cluster-file ../tests/data/differential_expression/sparse/sparsemini_cluster.txt --cluster-name de_sparse_integration --study-accession SCPsparsemini --differential-expression
+
+# Pairwise differential expression analysis (h5ad matrix)
+python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 differential_expression --annotation-name cell_type__ontology_label --de-type pairwise --group1 "['mature B cell']" --group2 "plasma cell" --annotation-type group --annotation-scope study --annotation-file ../tests/data/anndata/compliant_liver_h5ad_frag.metadata.tsv.gz --cluster-file ../tests/data/anndata/compliant_liver_h5ad_frag.cluster.X_umap.tsv.gz --cluster-name umap --matrix-file-path ../tests/data/anndata/compliant_liver.h5ad  --matrix-file-type h5ad --study-accession SCPdev --differential-expression
+
 """
 import json
 import logging

--- a/ingest/mongo_connection.py
+++ b/ingest/mongo_connection.py
@@ -34,7 +34,7 @@ class MongoConnection:
                 password=self.password,
                 authSource=self.db_name,
                 authMechanism="SCRAM-SHA-1",
-                serverSelectionTimeoutMS=60_000
+                serverSelectionTimeoutMS=60_000,
             )
             self._client = client[self.db_name]
         # Needed to due to lack of database mock library for MongoDB

--- a/ingest/validation/metadata_validation.py
+++ b/ingest/validation/metadata_validation.py
@@ -61,8 +61,7 @@ except ImportError:
 
 
 def create_parser():
-    """Parse command line values for validate_metadata
-    """
+    """Parse command line values for validate_metadata"""
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -122,8 +121,7 @@ def create_parser():
 
 
 def check_if_old_output():
-    """Exit if old output files found
-    """
+    """Exit if old output files found"""
     output_files = ["bq.json"]
 
     old_output = False

--- a/ingest/validation/validate_metadata.py
+++ b/ingest/validation/validate_metadata.py
@@ -57,8 +57,7 @@ MAX_HTTP_ATTEMPTS = 8
 
 
 def backoff_handler(details):
-    """Handler function to log backoff attempts when querying OLS
-    """
+    """Handler function to log backoff attempts when querying OLS"""
     dev_logger.debug(
         "Backing off {wait:0.1f} seconds after {tries} tries "
         "calling function {target} with args {args} and kwargs "
@@ -92,10 +91,10 @@ class OntologyRetriever:
 
         if term not in self.cached_terms[property_name]:
             ontology_urls = get_urls_for_property(convention, property_name)
-            self.cached_terms[property_name][
-                term
-            ] = self.retrieve_ontology_term_label_remote(
-                term, property_name, ontology_urls, attribute_type
+            self.cached_terms[property_name][term] = (
+                self.retrieve_ontology_term_label_remote(
+                    term, property_name, ontology_urls, attribute_type
+                )
             )
 
         return self.cached_terms[property_name][term]
@@ -103,8 +102,7 @@ class OntologyRetriever:
     def retrieve_ontology_term_label_remote(
         self, term, property_name, ontology_urls, attribute_type
     ):
-        """Look up official ontology term from an id, always checking against the remote
-        """
+        """Look up official ontology term from an id, always checking against the remote"""
         # organ_region currently uses single a non-OLS ontology, the Allen Institute's Mouse Brain Atlas (MBA)
         # MBA was originally downloaded April 2020 from Allen Brain Atlas data portal URL
         # http://api.brain-map.org/api/v2/data/query.csv?criteria=model::Structure,rma::criteria,[ontology_id$eq1],rma::options[order$eq%27structures.graph_order%27][num_rows$eqall]
@@ -218,8 +216,7 @@ class OntologyRetriever:
             raise RuntimeError(msg)
 
     def retrieve_mouse_brain_term(self, term, property_name):
-        """Determine whether ID is in mouse brain atlas (MBA) file
-        """
+        """Determine whether ID is in mouse brain atlas (MBA) file"""
         # MBA ID is also the leaf entity of structure_id_path in the MBA file
         # Entries with short structure_id_path seem to be synonymous with
         # Uberon terms, suggesting MBA terms could be mapped as extensions of the
@@ -233,18 +230,16 @@ class OntologyRetriever:
         return {"label": mouse_brain_atlas[MBA_id]}
 
     def fetch_allen_mouse_brain_atlas(self):
-        """Get the mouse brain atlas file, either remote or cached, and parse it into an id -> name dictionary
-        """
+        """Get the mouse brain atlas file, either remote or cached, and parse it into an id -> name dictionary"""
         if "allen_mouse_brain_atlas" not in self.cached_ontologies:
-            self.cached_ontologies[
-                "allen_mouse_brain_atlas"
-            ] = fetch_allen_mouse_brain_atlas_remote()
+            self.cached_ontologies["allen_mouse_brain_atlas"] = (
+                fetch_allen_mouse_brain_atlas_remote()
+            )
         return self.cached_ontologies["allen_mouse_brain_atlas"]
 
 
 def parse_organ_region_ontology_id(term):
-    """Extract term id from valid identifiers or raise a ValueError
-    """
+    """Extract term id from valid identifiers or raise a ValueError"""
     try:
         ontology_shortname, term_id = re.split("[_:]", term)
         if ontology_shortname == "MBA":
@@ -261,8 +256,7 @@ def parse_organ_region_ontology_id(term):
 
 
 def fetch_allen_mouse_brain_atlas_remote():
-    """Get the mouse brain atlas file from the remote source, and parse it into an id -> name dictionary
-    """
+    """Get the mouse brain atlas file from the remote source, and parse it into an id -> name dictionary"""
     MBA_url = "https://raw.githubusercontent.com/broadinstitute/scp-ingest-pipeline/58f9308e425c667a34219a3dcadf7209fe09f788/schema/organ_region/mouse_brain_atlas/MouseBrainAtlas.csv"
     region_dict = {}
     try:
@@ -311,8 +305,7 @@ def encode_term_iri(term_id, base_uri):
 
 
 def extract_terminal_pathname(url):
-    """Extract the last path segment from a URL
-    """
+    """Extract the last path segment from a URL"""
     return list(filter(None, url.split("/"))).pop()
 
 
@@ -321,8 +314,7 @@ def get_urls_for_property(convention, property_name):
 
 
 def get_ontology_file_location(ontology):
-    """Find and format fileLocation URL for running queries against an ontology
-    """
+    """Find and format fileLocation URL for running queries against an ontology"""
     location = ontology["config"]["fileLocation"]
     # issue with some ontologies (like GO) having non-standard fileLocation URLs
     if 'extensions' in location:
@@ -330,6 +322,7 @@ def get_ontology_file_location(ontology):
     if location == "http://purl.obolibrary.org/obo/NCBITAXON_":
         location = "http://purl.obolibrary.org/obo/NCBITaxon_"
     return '/'.join(location.split('/')[:-1]) + '/'
+
 
 ######################## END ONTOLOGY RETRIVER DEFINITION #########################
 
@@ -355,8 +348,7 @@ def validate_schema(json, metadata):
 
 
 def is_array_metadata(convention, metadatum):
-    """Check if metadata is array type from metadata convention
-    """
+    """Check if metadata is array type from metadata convention"""
     try:
         type_lookup = convention["properties"][metadatum]["type"]
         if type_lookup == "array":
@@ -368,8 +360,7 @@ def is_array_metadata(convention, metadatum):
 
 
 def is_ontology_metadata(convention, metadatum):
-    """Check if metadata is ontology from metadata convention
-    """
+    """Check if metadata is ontology from metadata convention"""
     try:
         return bool(convention["properties"][metadatum]["ontology"])
     except KeyError:
@@ -377,8 +368,7 @@ def is_ontology_metadata(convention, metadatum):
 
 
 def is_required_metadata(convention, metadatum):
-    """Check in metadata convention if metadata is required
-    """
+    """Check in metadata convention if metadata is required"""
     try:
         if metadatum in convention["required"]:
             return True
@@ -389,8 +379,7 @@ def is_required_metadata(convention, metadatum):
 
 
 def lookup_metadata_type(convention, metadatum):
-    """Look up metadata type from metadata convention
-    """
+    """Look up metadata type from metadata convention"""
     try:
         if is_array_metadata(convention, metadatum):
             type_lookup = convention["properties"][metadatum]["items"]["type"]
@@ -402,8 +391,7 @@ def lookup_metadata_type(convention, metadatum):
 
 
 def list_duplicates(cells):
-    """Find duplicates in list for detailed reporting
-    """
+    """Find duplicates in list for detailed reporting"""
     # reference https://stackoverflow.com/questions/9835762
     seen = set()
     # save add function to avoid repeated lookups
@@ -416,8 +404,7 @@ def list_duplicates(cells):
 
 
 def validate_cells_unique(metadata):
-    """Check all CellID are unique.
-    """
+    """Check all CellID are unique."""
     valid = False
     if len(metadata.cells) == len(set(metadata.cells)):
         valid = True
@@ -450,8 +437,10 @@ def insert_array_ontology_label_row_data(
         for id in row[property_name]:
             label_lookup = ""
             try:
-                label_and_synonyms = retriever.retrieve_ontology_term_label_and_synonyms(
-                    id, property_name, convention, "array"
+                label_and_synonyms = (
+                    retriever.retrieve_ontology_term_label_and_synonyms(
+                        id, property_name, convention, "array"
+                    )
                 )
                 label_lookup = label_and_synonyms.get('label')
                 reference_ontology = (
@@ -622,8 +611,7 @@ def collect_cell_for_ontology(
 
 
 def collect_ontology_data(row_data, metadata, convention):
-    """Collect unique ontology IDs for ontology validation
-    """
+    """Collect unique ontology IDs for ontology validation"""
     row_ref = copy.deepcopy(row_data)
     for entry in row_ref.keys():
         if is_ontology_metadata(convention, entry):
@@ -642,8 +630,7 @@ def collect_ontology_data(row_data, metadata, convention):
 
 
 def compare_type_annots_to_convention(metadata, convention):
-    """Check if metadata type annotation is consistent with metadata convention type
-    """
+    """Check if metadata type annotation is consistent with metadata convention type"""
     metadata_names = metadata.file.columns.get_level_values(0).tolist()
     type_annots = metadata.file.columns.get_level_values(1).tolist()
     # if input was TSV metadata file, SCP format requires 'NAME' for the first
@@ -697,8 +684,7 @@ def compare_type_annots_to_convention(metadata, convention):
 
 
 def cast_boolean_type(value):
-    """Cast metadata value as boolean, if castable
-    """
+    """Cast metadata value as boolean, if castable"""
     if isinstance(value, bool):
         return value
     elif str(value).lower() == "true":
@@ -727,8 +713,7 @@ def value_is_nan(value):
 
 
 def cast_integer_type(value):
-    """Cast metadata value as integer
-    """
+    """Cast metadata value as integer"""
     if value_is_nan(value):
         # nan indicates missing data, has no valid integer value for casting
         return value
@@ -737,14 +722,12 @@ def cast_integer_type(value):
 
 
 def cast_float_type(value):
-    """Cast metadata value as float
-    """
+    """Cast metadata value as float"""
     return float(value)
 
 
 def cast_string_type(value):
-    """Cast string type per convention where Pandas autodetected a number
-    """
+    """Cast string type per convention where Pandas autodetected a number"""
     if value_is_nan(value):
         # nan indicates missing data; by type, nan is a numpy float
         # so a separate type check is needed for proper handling
@@ -756,8 +739,7 @@ def cast_string_type(value):
 
 
 def regularize_ontology_id(value):
-    """Regularize ontology_ids for storage with underscore format
-    """
+    """Regularize ontology_ids for storage with underscore format"""
     try:
         return value.replace(":", "_")
     except AttributeError:
@@ -768,7 +750,7 @@ def regularize_ontology_id(value):
 
 def cast_metadata_type(metadatum, value, id_for_error_detail, convention, metadata):
     """For metadatum, lookup expected type by metadata convention
-        and cast value as appropriate type for validation
+    and cast value as appropriate type for validation
     """
     cast_metadata = {}
     metadata_types = {
@@ -1102,8 +1084,10 @@ def validate_collected_ontology_data(metadata, convention):
             try:
                 attribute_type = convention["properties"][property_name]["type"]
                 # get actual label along with synonyms for more robust matching
-                label_and_synonyms = retriever.retrieve_ontology_term_label_and_synonyms(
-                    ontology_id, property_name, convention, attribute_type
+                label_and_synonyms = (
+                    retriever.retrieve_ontology_term_label_and_synonyms(
+                        ontology_id, property_name, convention, attribute_type
+                    )
                 )
 
                 if not is_label_or_synonym(label_and_synonyms, ontology_label):
@@ -1213,16 +1197,14 @@ def calculate_organism_age_in_seconds(organism_age, organism_age_unit_label):
 
 
 def serialize_issues(metadata):
-    """Write collected issues to json file
-    """
+    """Write collected issues to json file"""
     with open("issues.json", "w") as jsonfile:
         json.dump(metadata.issues, jsonfile, indent=2)
         jsonfile.write("\n")  # Add newline cause Py JSON does not
 
 
 def review_metadata_names(metadata):
-    """Check metadata names for disallowed characters
-    """
+    """Check metadata names for disallowed characters"""
     metadata_names = metadata.file.columns.get_level_values(0).tolist()
     for name in metadata_names:
         allowed_char = re.compile("^[A-Za-z0-9_]+$")
@@ -1238,7 +1220,7 @@ def review_metadata_names(metadata):
 
 def identify_multiply_assigned(list):
     """Given a list of ontology IDs and their purported labels,
-        return list of unique multiply-assigned labels
+    return list of unique multiply-assigned labels
     """
     ontology_tracker = defaultdict(lambda: defaultdict(int))
     multiply_assigned = []
@@ -1293,13 +1275,13 @@ def assess_ontology_ids(ids, property_name, metadata):
 
 
 def detect_excel_drag(metadata, convention):
-    """ Check if ontology IDs submitted have characteristic Excel drag properties
-        Todo1: "Excel drag" detection of array-based ontologyID data
-        is lacking (need to track pipe-delimited string)
-        Todo2: need to bypass EBI OLS queries to "fill in"
-        missing ontology labels for optional metadata)
-        Hint: try working with raw metadata.file data, would
-        allow this check to be moved before collect_jsonschema_errors
+    """Check if ontology IDs submitted have characteristic Excel drag properties
+    Todo1: "Excel drag" detection of array-based ontologyID data
+    is lacking (need to track pipe-delimited string)
+    Todo2: need to bypass EBI OLS queries to "fill in"
+    missing ontology labels for optional metadata)
+    Hint: try working with raw metadata.file data, would
+    allow this check to be moved before collect_jsonschema_errors
     """
     excel_drag = False
     for property_name in metadata.ontology.keys():
@@ -1341,13 +1323,12 @@ def detect_excel_drag(metadata, convention):
 
 
 def to_1D(series):
-    """ Pandas values which are list need unnesting
-    """
+    """Pandas values which are list need unnesting"""
     return [x for _list in series for x in _list]
 
 
 def replace_single_value_array(df, metadata_name, synonym, label):
-    """ Synonym replacement (in-place) for single-value array metadata
+    """Synonym replacement (in-place) for single-value array metadata
     Pandas doesn't operate well on lists which are potentially non-homogenous
     # https://stackoverflow.com/questions/53116286/how-to-assign-an-entire-list-to-each-row-of-a-pandas-dataframe
     """
@@ -1357,9 +1338,9 @@ def replace_single_value_array(df, metadata_name, synonym, label):
 
 
 def replace_synonym_in_multivalue_array(df, metadata_name, substitutions):
-    """ Synonym replacement (in-place) for multi-value array ontology labels
-        must identify all affected arrays of labels, construct replacement arrays
-        then replace old synonym-containing array with an updated array
+    """Synonym replacement (in-place) for multi-value array ontology labels
+    must identify all affected arrays of labels, construct replacement arrays
+    then replace old synonym-containing array with an updated array
     """
     orig_values = list(df[metadata_name].transform(tuple).unique())
     matching_synonyms = {}
@@ -1416,8 +1397,7 @@ def replace_synonyms(metadata):
 
 
 def validate_input_metadata(metadata, convention, bq_json=None):
-    """Wrapper function to run validation functions
-    """
+    """Wrapper function to run validation functions"""
     dev_logger.info("Checking metadata content against convention rules")
     collect_jsonschema_errors(metadata, convention, bq_json)
     review_metadata_names(metadata)
@@ -1434,8 +1414,7 @@ def validate_input_metadata(metadata, convention, bq_json=None):
 
 
 def push_metadata_to_bq(metadata, ndjson, dataset, table):
-    """Upload local NDJSON to BigQuery
-    """
+    """Upload local NDJSON to BigQuery"""
     client = bigquery.Client()
     dataset_ref = client.dataset(dataset)
     table_ref = dataset_ref.table(table)
@@ -1468,16 +1447,14 @@ def push_metadata_to_bq(metadata, ndjson, dataset, table):
 
 
 def write_metadata_to_bq(metadata, bq_dataset, bq_table):
-    """Wrapper function to gather metadata and write to BigQuery
-    """
+    """Wrapper function to gather metadata and write to BigQuery"""
     bq_filename = str(metadata.study_file_id) + ".json"
     push_status = push_metadata_to_bq(metadata, bq_filename, bq_dataset, bq_table)
     return push_status
 
 
 def check_if_old_output():
-    """Exit if old output files found
-    """
+    """Exit if old output files found"""
     output_files = ["bq.json"]
 
     old_output = False
@@ -1487,4 +1464,3 @@ def check_if_old_output():
             old_output = True
     if old_output:
         exit(1)
-

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -519,6 +519,42 @@ class TestDifferentialExpression(unittest.TestCase):
                 "expected one call to delocalize output files",
             )
 
+        test_config = {
+            "de_type": "pairwise",
+            "group1": ['NO SUCH GROUP VALUE'],
+            "group2": "plasma cell",
+            "test_annotation": test_annotation,
+            "test_scope": "study",
+            "test_method": "wilcoxon",
+            "annot_path": "../tests/data/anndata/compliant_liver_h5ad_frag.metadata.tsv.gz",
+            "study_accession": "SCPh5adde",
+            "cluster_path": "../tests/data/anndata/compliant_liver_h5ad_frag.cluster.X_umap.tsv.gz",
+            "cluster_name": "umap",
+            "matrix_file": "../tests/data/anndata/compliant_liver.h5ad",
+            "matrix_type": "h5ad",
+        }
+
+        self.assertRaises(
+        ValueError, run_de, **test_config)
+
+        test_config = {
+            "de_type": "pairwise",
+            "group1": [],
+            "group2": "plasma cell",
+            "test_annotation": test_annotation,
+            "test_scope": "study",
+            "test_method": "wilcoxon",
+            "annot_path": "../tests/data/anndata/compliant_liver_h5ad_frag.metadata.tsv.gz",
+            "study_accession": "SCPh5adde",
+            "cluster_path": "../tests/data/anndata/compliant_liver_h5ad_frag.cluster.X_umap.tsv.gz",
+            "cluster_name": "umap",
+            "matrix_file": "../tests/data/anndata/compliant_liver.h5ad",
+            "matrix_type": "h5ad",
+        }
+        # Original error is KeyError but all errors passed through assess_annotation become ValueErrors
+        self.assertRaises(
+        ValueError, run_de, **test_config)
+
         # clean up DE outputs
         files = glob.glob(expected_output_match)
 

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -48,7 +48,7 @@ def find_expected_files(labels, cluster_name, test_config):
     elif de_type == "pairwise":
         # rank_genes_groups accepts a list. For SCP pairwise, should be a list with one item
         # converting list to string for incorporation into result filename
-        group1 = DifferentialExpression.sanitize_string(''.join(test_config["group1"]))
+        group1 = DifferentialExpression.sanitize_string(test_config["group1"])
         group2 = DifferentialExpression.sanitize_string(test_config["group2"])
         expected_file = f'{sanitized_cluster_name}--{sanitized_annotation}--{group1}--{group2}--{annot_scope}--{method}.tsv'
         assert os.path.exists(expected_file)
@@ -443,7 +443,7 @@ class TestDifferentialExpression(unittest.TestCase):
         test_annotation = "cell_type__ontology_label"
         test_config = {
             "de_type": "pairwise",
-            "group1": ['mature B cell'],
+            "group1": "mature B cell",
             "group2": "plasma cell",
             "test_annotation": test_annotation,
             "test_scope": "study",
@@ -518,7 +518,7 @@ class TestDifferentialExpression(unittest.TestCase):
 
         test_config = {
             "de_type": "pairwise",
-            "group1": ['NO SUCH GROUP VALUE'],
+            "group1": "NO SUCH GROUP VALUE",
             "group2": "plasma cell",
             "test_annotation": test_annotation,
             "test_scope": "study",
@@ -536,7 +536,7 @@ class TestDifferentialExpression(unittest.TestCase):
 
         test_config = {
             "de_type": "pairwise",
-            "group1": [],
+            "group1": "",
             "group2": "plasma cell",
             "test_annotation": test_annotation,
             "test_scope": "study",

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -35,8 +35,10 @@ def find_expected_files(labels, cluster_name, test_config):
     """Check that files were created for all expected annotation labels"""
     found = []
     sanitized_cluster_name = DifferentialExpression.sanitize_string(cluster_name)
-    sanitized_annotation = DifferentialExpression.sanitize_string(test_config.get("test_annotation"))
-    de_type =  test_config.get("de_type")
+    sanitized_annotation = DifferentialExpression.sanitize_string(
+        test_config.get("test_annotation")
+    )
+    de_type = test_config.get("de_type")
     method = test_config.get("test_method")
     annot_scope = test_config.get("test_scope")
     if de_type == "rest":
@@ -68,7 +70,6 @@ def run_de(**test_config):
     matrix_type = test_config["matrix_type"]
     de_type = test_config["de_type"]
 
-
     cm = CellMetadata(
         annot_path,
         "addedfeed000000000000000",
@@ -91,7 +92,7 @@ def run_de(**test_config):
             "method": test_method,
             "de_type": de_type,
             "group1": test_config["group1"],
-            "group2": test_config["group2"]
+            "group2": test_config["group2"],
         }
     else:
         de_kwargs = {
@@ -116,9 +117,7 @@ def run_de(**test_config):
     labels = get_annotation_labels(cm, test_annotation, de_cells)
     # In find_expected_files, checks all files with expected names were created
     # yields the number of files expected for an external check for file count
-    found_labels = find_expected_files(
-        labels, cluster.name, test_config
-    )
+    found_labels = find_expected_files(labels, cluster.name, test_config)
     return found_labels
 
 
@@ -152,22 +151,34 @@ class TestDifferentialExpression(unittest.TestCase):
             tracer=None,
         )
         extra_params = {
-             "de_type": "rest",
-         }
+            "de_type": "rest",
+        }
         # alter metadata so seurat_clusters is TYPE numeric
         cm.annot_types[21] = 'numeric'
         self.assertRaises(
-            TypeError, DifferentialExpression.assess_annotation, test_annotation, cm, extra_params
+            TypeError,
+            DifferentialExpression.assess_annotation,
+            test_annotation,
+            cm,
+            extra_params,
         )
         # alter metadata so seurat_clusters has bad TYPE designation
         cm.annot_types[21] = 'foo'
         self.assertRaises(
-            ValueError, DifferentialExpression.assess_annotation, test_annotation, cm, extra_params
+            ValueError,
+            DifferentialExpression.assess_annotation,
+            test_annotation,
+            cm,
+            extra_params,
         )
         # remove seurat_clusters from metadata
         cm.headers.pop(21)
         self.assertRaises(
-            KeyError, DifferentialExpression.assess_annotation, test_annotation, cm, extra_params
+            KeyError,
+            DifferentialExpression.assess_annotation,
+            test_annotation,
+            cm,
+            extra_params,
         )
 
     def test_detect_duplicate_gene_names(self):
@@ -402,7 +413,9 @@ class TestDifferentialExpression(unittest.TestCase):
             "Did not find expected logfoldchange value for Sox17 in DE file.",
         )
         # confirm duplicate gene input generates expected gene_id info in output
-        self.assertIn('feature_id', content.columns, "Expected feature_id output not found.")
+        self.assertIn(
+            'feature_id', content.columns, "Expected feature_id output not found."
+        )
 
         # md5 checksum calculated using reference file in tests/data/differential_expression/sparse/reference
         expected_checksum = "7b13cb24b020aca268015e714ca2d666"
@@ -465,12 +478,9 @@ class TestDifferentialExpression(unittest.TestCase):
             f"expected one annotation label for pairwise DE with {test_annotation}",
         )
 
-        expected_file = (
-           "umap--cell_type__ontology_label--mature_B_cell--plasma_cell--study--wilcoxon.tsv"
-        )
+        expected_file = "umap--cell_type__ontology_label--mature_B_cell--plasma_cell--study--wilcoxon.tsv"
 
         expected_file_path = f"../tests/{expected_file}"
-
         # confirm expected results filename was generated in found result files
         self.assertIn(
             expected_file, found_labels, "Expected filename not in found files list"
@@ -503,7 +513,9 @@ class TestDifferentialExpression(unittest.TestCase):
             "Generated output file should match expected checksum.",
         )
 
-        expected_output_match = "umap--cell_type__ontology_label--*--study--wilcoxon.tsv"
+        expected_output_match = (
+            "umap--cell_type__ontology_label--*--study--wilcoxon.tsv"
+        )
 
         with patch('ingest_files.IngestFiles.delocalize_file'):
             DifferentialExpression.delocalize_de_files(
@@ -531,8 +543,7 @@ class TestDifferentialExpression(unittest.TestCase):
             "matrix_type": "h5ad",
         }
 
-        self.assertRaises(
-        ValueError, run_de, **test_config)
+        self.assertRaises(ValueError, run_de, **test_config)
 
         test_config = {
             "de_type": "pairwise",
@@ -549,8 +560,7 @@ class TestDifferentialExpression(unittest.TestCase):
             "matrix_type": "h5ad",
         }
         # Original error is KeyError but all errors passed through assess_annotation become ValueErrors
-        self.assertRaises(
-        ValueError, run_de, **test_config)
+        self.assertRaises(ValueError, run_de, **test_config)
 
         # clean up DE outputs
         files = glob.glob(expected_output_match)

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -43,20 +43,17 @@ def find_expected_files(labels, cluster_name, test_config):
         for label in labels:
             sanitized_label = DifferentialExpression.sanitize_string(label)
             expected_file = f"{sanitized_cluster_name}--{sanitized_annotation}--{sanitized_label}--{annot_scope}--{method}.tsv"
-            print(f'expected_file, {expected_file}')
             assert os.path.exists(expected_file)
             found.append(expected_file)
-        return found
     elif de_type == "pairwise":
         # rank_genes_groups accepts a list. For SCP pairwise, should be a list with one item
         # converting list to string for incorporation into result filename
         group1 = DifferentialExpression.sanitize_string(''.join(test_config["group1"]))
         group2 = DifferentialExpression.sanitize_string(test_config["group2"])
         expected_file = f'{sanitized_cluster_name}--{sanitized_annotation}--{group1}--{group2}--{annot_scope}--{method}.tsv'
-        print(f'expected_file, {expected_file}')
         assert os.path.exists(expected_file)
         found.append(expected_file)
-        return found
+    return found
 
 
 def run_de(**test_config):


### PR DESCRIPTION
#### BACKGROUND & CHANGES

This update adds pairwise DE to ingest pipeline. A new `--differential-expression` ingest pipeline parameter, `--de-type` is instantiated as "rest" by default, allowing existing "one vs rest" invocations to remain unchanged. Pairwise invocations add two additional parameters `--group1` and `--group2`. ~~Scanpy's rank_genes_groups function will accept a list of annotation values for "--group1", while we won't be taking advantage of that capability, it does require `--group1` to be passed as a list~~. Both `--group1` and `--group2` ~~is~~ passed as ~~a simple~~ string.

#### MANUAL TESTING

Testing using ingest_pipeline CLI requires an AnnData file and cluster & metadata AnnData fragments extracted from the AnnData file. 
1. Download the following files (you may already have them from PR#372):
	**HTAPP-330-SMP-1082_compliant.h5ad**: gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/differential_expression/HTAPP-330-SMP-1082/HTAPP-330-SMP-1082_compliant.h5ad
	**HTAPP-330-SMP-1082_h5ad_frag.cluster.X_umap.tsv.gz**: gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/differential_expression/HTAPP-330-SMP-1082/HTAPP-330-SMP-1082_h5ad_frag.cluster.X_umap.tsv.gz (Note: file will lose the .gz suffix BUT will still need to be decompressed :(
	**HTAPP-330-SMP-1082_h5ad_frag.metadata.tsv.gz**: gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/differential_expression/HTAPP-330-SMP-1082/HTAPP-330-SMP-1082_h5ad_frag.metadata.tsv.gz (Note: file will lose the .gz suffix BUT will still need to be decompressed :(1. Initialize your dev environment and ```export BYPASS_MONGO_WRITES='yes'```
1. Run the following ingest pipeline job: 
`python ingest_pipeline.py --study-id addedfeed000000000000000 --study-file-id dec0dedfeed1111111111111 differential_expression --annotation-name leiden --de-type pairwise --group1 "1" --group2 "2" --annotation-type group --annotation-scope study --annotation-file HTAPP-330-SMP-1082_h5ad_frag.metadata.tsv.gz --cluster-file HTAPP-330-SMP-1082_h5ad_frag.cluster.X_umap.tsv.gz --cluster-name umap --matrix-file-path HTAPP-330-SMP-1082_compliant.h5ad  --matrix-file-type h5ad --study-accession SCPdev --differential-expression`
1. Confirm that the job generates "umap--leiden--1--2--study--wilcoxon.tsv"
1. [optional] Compare your output to the reference output file in the reference google bucket at gs://fc-2f8ef4c0-b7eb-44b1-96fe-a07f0ea9a982/test_Data/differential_expression/HTAPP-330-SMP-1082/umap--leiden--1--2--study--wilcoxon.tsv