### PR TITLE
Update docker-compose-setup.sh to use GAR (SCP-5153)

### DIFF
--- a/scripts/docker-compose-setup.sh
+++ b/scripts/docker-compose-setup.sh
@@ -35,8 +35,18 @@ case $OPTION in
 done
 
 if [[ $GCR_IMAGE = "" ]]; then
-  IMAGE_NAME="gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline-development"
-  LATEST_TAG=$(gcloud container images list-tags ${IMAGE_NAME} --format='get(tags)' | head -n 1)
+  # Google Artifact Registry (GAR) formats Docker image names differently than the canonical Container Registry format
+  # both refer to the same image digest and will work with 'docker pull', but the GCR names do not work with any
+  # 'gcloud artifacts docker' commands
+  # for example:
+  # GCR name: gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline-development
+  # GAR name: us-docker.pkg.dev/broad-singlecellportal-staging/gcr.io/scp-ingest-pipeline-development
+  REPO='gcr.io'
+  PROJECT='broad-singlecellportal-staging'
+  IMAGE='scp-ingest-pipeline-development'
+  GAR_NAME="us-docker.pkg.dev/$PROJECT/$REPO/$IMAGE"
+  IMAGE_NAME="$REPO/$PROJECT/$IMAGE"
+  LATEST_TAG=$(gcloud artifacts docker images list ${GAR_NAME} --include-tags --sort-by=~CREATE_TIME --format="get(tags)" | head -n 1)
   export GCR_IMAGE="${IMAGE_NAME}:${LATEST_TAG}"
 fi
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
Similar to https://github.com/broadinstitute/single_cell_portal_core/pull/2187, this updates any `gcloud` commands that used Container Registry to now use Artifact Registry.  This is part of the mandatory switchover that must be completed by the end of March 2025.

#### MANUAL TESTING
1. Ensure Docker is running
2. Go to the project directory and run the `docker-compose-setup.sh` script, confirming you are left inside the running Docker container:
```
$ scripts/docker-compose-setup.sh 
...
Listing items under project broad-singlecellportal-staging, location us, repository gcr.io.

### SETTING UP ENVIRONMENT ###
704fa3f: Pulling from broad-singlecellportal-staging/scp-ingest-pipeline-development
Digest: sha256:004e30bb0c98e31f17e707ac2a391f8ce320823d3bbde568db534c739013d32f
Status: Image is up to date for gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline-development:704fa3f
gcr.io/broad-singlecellportal-staging/scp-ingest-pipeline-development:704fa3f
...

root@068c1a08ccae:/scp-ingest-pipeline/ingest# 
```

Note: if you receive a `scripts/docker-compose-setup.sh: line 60: docker-compose: command not found` error, run the remediation steps listed at https://docs.docker.com/compose/install/ regarding the issue with `docker-compose` in versions after 4.23.