### PR TITLE
Add STDOUT logging handler for Cloud Logging integration (SCP-5902)

### DIFF
--- a/ingest/de.py
+++ b/ingest/de.py
@@ -367,7 +367,7 @@ class DifferentialExpression:
             clean_group = DifferentialExpression.sanitize_string(group)
             out_file = f'{cluster_name}--{clean_annotation}--{clean_group}--{annot_scope}--{method}.tsv'
             DifferentialExpression.de_logger.info(
-                f"Writing DE output for {clean_group} vs restq"
+                f"Writing DE output for {clean_group} vs rest"
             )
         elif de_type == "pairwise":
             # rank_genes_groups accepts a list. For SCP pairwise, should be a list with one item

--- a/ingest/monitor.py
+++ b/ingest/monitor.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from contextlib import nullcontext
 
 # General docs for Sentry:
@@ -41,6 +42,8 @@ def setup_logger(logger_name, log_file, level=logging.DEBUG, format="default"):
         logger.propagate = True
     logger.setLevel(level)
     logger.addHandler(handler)
+    # also log to STDOUT to pass to cloud logging
+    logger.addHandler(logging.StreamHandler(sys.stdout))
     return logger
 
 


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This update adds a logging handler for `STDOUT` to supplement the existing logging for ingest processes.  By adding this, we will leverage the existing integration of cloud logging into Batch API jobs.  This will add much greater visibility for jobs as we will not need to rely on the log file being delocalized back to the bucket.  This benefits running jobs the most as we will get real-time log messages, allowing us to debug the state of a job without waiting for completion.

Note: This also contains an unrelated update to the `vault-gsm-migration.sh` script that was needed to help import secrets from Vault into GSM better.

#### MANUAL TESTING
1. Initialize your environment as normal and run the following command from the `ingest` folder:
```
python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_cluster --cluster-file ../tests/data/test_1k_cluster_data.csv --ingest-cluster --name cluster1 --domain-ranges "{'x':[-1, 1], 'y':[-1, 1], 'z':[-1, 1]}"
```

2. In addition to normal output, you should see messages that normally would only print to `user_log.txt`:

```
Transforming header CLUSTER
Transforming header SUBCLUSTER
Transforming header 1
Creating model for 5d276a50421aa9117c982845
Creating data array for header NAME
Attempting to load cluster header : NAME
Creating data array for header x
Attempting to load cluster header : x
Creating data array for header y
Attempting to load cluster header : y
Creating data array for header z
Attempting to load cluster header : z
Creating data array for header CLUSTER
Attempting to load cluster header : CLUSTER
Creating data array for header SUBCLUSTER
Attempting to load cluster header : SUBCLUSTER
Creating data array for header 1
Attempting to load cluster header : 1
```
