### PR TITLE
Handle invalid obsm keys with actionable error message

### DIFF
--- a/ingest/cli_parser.py
+++ b/ingest/cli_parser.py
@@ -281,6 +281,13 @@ def create_parser():
     )
 
     parser_differential_expression.add_argument(
+        "--raw-location",
+        required=True,
+        help="location of raw counts. '.raw' for raw slot, "
+        "else adata.layers key value",
+    )
+
+    parser_differential_expression.add_argument(
         "--study-accession",
         required=True,
         help="Single study accession associated with provided DE input files.",

--- a/ingest/de.py
+++ b/ingest/de.py
@@ -367,7 +367,7 @@ class DifferentialExpression:
             clean_group = DifferentialExpression.sanitize_string(group)
             out_file = f'{cluster_name}--{clean_annotation}--{clean_group}--{annot_scope}--{method}.tsv'
             DifferentialExpression.de_logger.info(
-                f"Writing DE output for {clean_group} vs restq"
+                f"Writing DE output for {clean_group} vs rest"
             )
         elif de_type == "pairwise":
             # rank_genes_groups accepts a list. For SCP pairwise, should be a list with one item

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -553,6 +553,12 @@ class IngestPipeline:
                             self.anndata.adata, key
                         )
                         AnnDataIngestor.generate_cluster_body(self.anndata.adata, key)
+                except KeyError as e:
+                    msg = f"KeyError: {e} - Unable to extract cluster data from anndata file. Please check the provided obsm key."
+                    log_exception(
+                        IngestPipeline.dev_logger, IngestPipeline.user_logger, msg
+                    )
+                    return 1
                 except Exception as e:
                     log_exception(
                         IngestPipeline.dev_logger, IngestPipeline.user_logger, e

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -546,12 +546,18 @@ class IngestPipeline:
                 if not self.kwargs["obsm_keys"]:
                     self.kwargs["obsm_keys"] = ["X_tsne"]
                 # TODO (SCP-5104): perform check for successful extraction or report failure and exit
-                for key in self.kwargs["obsm_keys"]:
-                    AnnDataIngestor.generate_cluster_header(self.anndata.adata, key)
-                    AnnDataIngestor.generate_cluster_type_declaration(
-                        self.anndata.adata, key
+                try:
+                    for key in self.kwargs["obsm_keys"]:
+                        AnnDataIngestor.generate_cluster_header(self.anndata.adata, key)
+                        AnnDataIngestor.generate_cluster_type_declaration(
+                            self.anndata.adata, key
+                        )
+                        AnnDataIngestor.generate_cluster_body(self.anndata.adata, key)
+                except Exception as e:
+                    log_exception(
+                        IngestPipeline.dev_logger, IngestPipeline.user_logger, e
                     )
-                    AnnDataIngestor.generate_cluster_body(self.anndata.adata, key)
+                    return 1
             # process matrix data
             ### TODO (SCP-5102, SCP-5103): how to associate "raw_count" cells to anndata file
             if self.kwargs.get("extract") and "processed_expression" in self.kwargs.get(

--- a/ingest/ingest_pipeline.py
+++ b/ingest/ingest_pipeline.py
@@ -554,7 +554,8 @@ class IngestPipeline:
                         )
                         AnnDataIngestor.generate_cluster_body(self.anndata.adata, key)
                 except KeyError as e:
-                    msg = f"KeyError: {e} - Unable to extract cluster data from anndata file. Please check the provided obsm key."
+                    msg = f"Unable to extract cluster data from anndata file. Please check the provided obsm key, {e}."
+                    self.report_validation("failure")
                     log_exception(
                         IngestPipeline.dev_logger, IngestPipeline.user_logger, msg
                     )

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -98,6 +98,17 @@ class TestAnnDataIngestor(unittest.TestCase):
             "h5ad_frag.cluster.X_Umap.tsv",
         )
 
+    def test_invalid_obsm_key(self):
+        valid_synthetic_anndata = AnnDataIngestor(*self.synthetic_args)
+        invalid_cluster_name = "foo"
+        self.assertRaisesRegex(
+            KeyError,
+            "foo",
+            lambda: self.anndata_ingest.generate_cluster_header(
+                valid_synthetic_anndata.obtain_adata(), invalid_cluster_name
+            ),
+        )
+
     def test_generate_cluster_header(self):
         self.anndata_ingest.generate_cluster_header(
             self.anndata_ingest.obtain_adata(), self.cluster_name

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -31,6 +31,7 @@ pytest -n auto -s
 pytest --cov=../ingest/
 
 """
+
 import unittest
 from unittest.mock import patch, MagicMock
 from test_dense import mock_load_r_files
@@ -47,7 +48,7 @@ from ingest_pipeline import (
     IngestPipeline,
     exit_pipeline,
     run_ingest,
-    get_action_from_args
+    get_action_from_args,
 )
 from expression_files.expression_files import GeneExpression
 
@@ -102,8 +103,7 @@ class IngestTestCase(unittest.TestCase):
         return_value=True,
     )
     def test_ingest_dense_matrix(self, mock_check_unique_cells):
-        """Ingest Pipeline should extract, transform, and load dense matrices
-        """
+        """Ingest Pipeline should extract, transform, and load dense matrices"""
         args = [
             "--study-id",
             "5d276a50421aa9117c982845",
@@ -132,8 +132,7 @@ class IngestTestCase(unittest.TestCase):
         return_value=True,
     )
     def test_ingest_local_dense_matrix(self, mock_check_unique_cells):
-        """Ingest Pipeline should extract and transform local dense matrices
-        """
+        """Ingest Pipeline should extract and transform local dense matrices"""
 
         args = [
             "--study-id",
@@ -164,7 +163,7 @@ class IngestTestCase(unittest.TestCase):
     )
     def test_ingest_local_compressed_dense_matrix(self, mock_check_unique_cells):
         """Ingest Pipeline should extract and transform local dense matrices
-            from compressed file in the same manner as uncompressed file
+        from compressed file in the same manner as uncompressed file
         """
 
         args = [
@@ -191,8 +190,7 @@ class IngestTestCase(unittest.TestCase):
         self.execute_ingest(args)
 
     def test_empty_dense_file(self):
-        """Ingest Pipeline should fail gracefully when an empty file is given
-        """
+        """Ingest Pipeline should fail gracefully when an empty file is given"""
 
         args = [
             "--study-id",
@@ -222,8 +220,7 @@ class IngestTestCase(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
     def test_empty_mtx_file(self):
-        """Ingest Pipeline should fail gracefully when an empty file is given
-        """
+        """Ingest Pipeline should fail gracefully when an empty file is given"""
 
         args = [
             "--study-id",
@@ -261,8 +258,7 @@ class IngestTestCase(unittest.TestCase):
         return_value=True,
     )
     def test_ingest_mtx_matrix(self, mock_check_unique_cells):
-        """Ingest Pipeline should extract and transform MTX matrix bundles
-        """
+        """Ingest Pipeline should extract and transform MTX matrix bundles"""
 
         args = [
             "--study-id",
@@ -296,8 +292,7 @@ class IngestTestCase(unittest.TestCase):
         return_value=True,
     )
     def test_ingest_unsorted_mtx_matrix(self, mock_check_unique_cells):
-        """Ingest Pipeline should extract and transform unsorted MTX matrix bundles
-        """
+        """Ingest Pipeline should extract and transform unsorted MTX matrix bundles"""
 
         args = [
             "--study-id",
@@ -331,8 +326,7 @@ class IngestTestCase(unittest.TestCase):
         return_value=True,
     )
     def test_ingest_zipped_mtx_matrix(self, mock_check_unique_cells):
-        """Ingest Pipeline should extract and transform MTX matrix bundles
-        """
+        """Ingest Pipeline should extract and transform MTX matrix bundles"""
 
         args = [
             "--study-id",
@@ -366,8 +360,7 @@ class IngestTestCase(unittest.TestCase):
         return_value=True,
     )
     def test_remote_mtx_bundles(self, mock_check_unique_cells):
-        """Ingest Pipeline should handle MTX matrix files fetched from bucket
-        """
+        """Ingest Pipeline should handle MTX matrix files fetched from bucket"""
 
         args = [
             "--study-id",
@@ -402,8 +395,7 @@ class IngestTestCase(unittest.TestCase):
         return_value=True,
     )
     def test_mtx_bundle_argument_validation(self, mock_check_unique_cells):
-        """Omitting --gene-file and --barcode-file in MTX ingest should error
-        """
+        """Omitting --gene-file and --barcode-file in MTX ingest should error"""
 
         args = [
             "--study-id",
@@ -452,8 +444,7 @@ class IngestTestCase(unittest.TestCase):
         self.execute_ingest(args)
 
     def test_good_metadata_file(self):
-        """Ingest Pipeline should succeed for properly formatted metadata file
-        """
+        """Ingest Pipeline should succeed for properly formatted metadata file"""
         args = [
             "--study-id",
             "5d276a50421aa9117c982845",
@@ -488,7 +479,7 @@ class IngestTestCase(unittest.TestCase):
         self, mock_check_unique_cells, mock_load
     ):
         """Ingest Pipeline should not succeed if mongo cannot connect after 5
-            reconnection tries.
+        reconnection tries.
         """
         args = [
             "--study-id",
@@ -522,8 +513,7 @@ class IngestTestCase(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
     def test_bad_metadata_file(self):
-        """Ingest Pipeline should not succeed for misformatted metadata file
-        """
+        """Ingest Pipeline should not succeed for misformatted metadata file"""
 
         args = [
             "--study-id",
@@ -565,8 +555,7 @@ class IngestTestCase(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
     def test_good_cluster_file(self):
-        """Ingest Pipeline should succeed for properly formatted cluster file
-        """
+        """Ingest Pipeline should succeed for properly formatted cluster file"""
         args = [
             "--study-id",
             "5d276a50421aa9117c982845",
@@ -590,8 +579,7 @@ class IngestTestCase(unittest.TestCase):
         self.assertEqual(status[0], None)
 
     def test_bad_cluster_file(self):
-        """Ingest Pipeline should fail for misformatted cluster file
-        """
+        """Ingest Pipeline should fail for misformatted cluster file"""
         args = [
             "--study-id",
             "5d276a50421aa9117c982845",
@@ -611,8 +599,7 @@ class IngestTestCase(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
     def test_bad_cluster_missing_coordinate_file(self):
-        """Ingest Pipeline should fail for missing coordinate in cluster file
-        """
+        """Ingest Pipeline should fail for missing coordinate in cluster file"""
         args = [
             "--study-id",
             "5d276a50421aa9117c982845",
@@ -633,8 +620,7 @@ class IngestTestCase(unittest.TestCase):
 
     @patch("ingest_pipeline.IngestPipeline.load_subsample", return_value=0)
     def test_subsample(self, mock_load_subsample):
-        """When cell values in cluster are present in cell metadata file ingest should succeed.
-        """
+        """When cell values in cluster are present in cell metadata file ingest should succeed."""
         args = [
             "--study-id",
             "5d276a50421aa9117c982845",
@@ -689,8 +675,7 @@ class IngestTestCase(unittest.TestCase):
 
     @patch("ingest_pipeline.IngestPipeline.load_subsample", return_value=0)
     def test_subsample_no_cell_intersection(self, mock_load_subsample):
-        """When cell values in cluster are not present in cell metadata file ingest should fail.
-        """
+        """When cell values in cluster are not present in cell metadata file ingest should fail."""
         args = [
             "--study-id",
             "5d276a50421aa9117c982845",
@@ -736,6 +721,24 @@ class IngestTestCase(unittest.TestCase):
             os.remove(filename)
         except:
             print(f"Error while deleting file : {filename}")
+
+    def test_invalid_obsm_key_for_anndata(self):
+        args = [
+            "--study-id",
+            "5d276a50421aa9117c982845",
+            "--study-file-id",
+            "5dd5ae25421aa910a723a337",
+            "ingest_anndata",
+            "--ingest-anndata",
+            "--extract",
+            "['cluster']",
+            "--anndata-file",
+            "../tests/data/anndata/trimmed_compliant_pbmc3K.h5ad",
+            "--obsm-keys",
+            "['foo']",
+        ]
+        ingest, arguments, status, status_cell_metadata = self.execute_ingest(args)
+        self.assertEqual(status[0], 1)
 
     def test_extract_metadata_file_from_anndata(self):
         args = [
@@ -857,16 +860,12 @@ class IngestTestCase(unittest.TestCase):
         client_mock["data_arrays"].insert_many.assert_called_with(docs)
 
         client_mock["data_arrays"].insert_many.side_effect = ValueError("Foo")
-        self.assertRaises(
-            Exception, ingest.insert_many, "data_arrays", docs
-        )
+        self.assertRaises(Exception, ingest.insert_many, "data_arrays", docs)
         client_mock.reset_mock()
 
         # Test exponential back off for auto reconnect
         client_mock["data_arrays"].insert_many.side_effect = AutoReconnect
-        self.assertRaises(
-            AutoReconnect, ingest.insert_many, "data_arrays", docs
-        )
+        self.assertRaises(AutoReconnect, ingest.insert_many, "data_arrays", docs)
         self.assertEqual(client_mock["data_arrays"].insert_many.call_count, 3)
         client_mock.reset_mock()
 
@@ -890,9 +889,7 @@ class IngestTestCase(unittest.TestCase):
 
         # Test exponential back off for BulkWriteError
         client_mock["data_arrays"].insert_many.side_effect = raiseError
-        self.assertRaises(
-            BulkWriteError, ingest.insert_many, "data_arrays", docs
-        )
+        self.assertRaises(BulkWriteError, ingest.insert_many, "data_arrays", docs)
         self.assertEqual(client_mock["data_arrays"].insert_many.call_count, 3)
 
 


### PR DESCRIPTION
### Background

Previously when a user enters an incorrect obsm_key, AnnData ingest failed with a KeyError, resulting in “Unexpected exit status 1”.  With the switch Batch API, the KeyError messaging is swallowed entirely, obscuring the cause of the failure for the study owner and makes troubleshooting take longer for an SCP admin.

### Manual testing
1. Set up for ingest testing as per usual (from ingest directory, run source ../scripts/setup-mongo-dev.sh)
2. Run the following ingest pipeline job:
`python ingest_pipeline.py --study-id 5d276a50421aa9117c982845 --study-file-id 5dd5ae25421aa910a723a337 ingest_anndata --extract "['cluster']" --ingest-anndata --anndata-file ../tests/data/anndata/anndata_test.h5ad --obsm-keys "['foo']"`
3. Confirm that user.log contains
> Unable to extract cluster data from anndata file. Please check the provided obsm key, 'foo'.

[optional]
1. Boot as normal in your local instance
2. Set the ingest docker image for your local instance to:  `gcr.io/broad-singlecellportal-staging/scp-ingest-jlc_report_obsm_error:d20f5b8`
3. Run an anndata ingest, supplying an invalid obsm key
4. Confirm that the ingest error email now clearly indicates the issue. Error message should be similar to:
> "Unable to extract cluster data from anndata file. Please check the provided obsm key, 'foo'."